### PR TITLE
Use pointer types for pointers

### DIFF
--- a/config.h
+++ b/config.h
@@ -13,4 +13,11 @@
 #   endif
 #endif
 
+/* Static assertion trick */
+enum { ASSERT_POINTER_FITS_IN_LONG_INT = 1/(!!(
+        sizeof(long int) >= sizeof(void*)
+)) };
+
+typedef signed long int register_type;
+
 #endif

--- a/ptrace_utils.h
+++ b/ptrace_utils.h
@@ -1,12 +1,12 @@
 #ifndef PTRACE_UTILS_H
 #define PTRACE_UTILS_H
 
-size_t tracee_strlen(pid_t pid, size_t ptr);
+size_t tracee_strlen(pid_t pid, const char *str);
 
-void tracee_read(pid_t pid, char *dst, size_t ptr, size_t size);
+void tracee_read(pid_t pid, char *dst, const char *src, size_t size);
 
-char *tracee_strdup(pid_t pid, size_t ptr);
+char *tracee_strdup(pid_t pid, const char *str);
 
-char **tracee_strarraydup(pid_t pid, size_t ptr);
+char **tracee_strarraydup(pid_t pid, const char *const *argv);
 
 #endif

--- a/tracer.c
+++ b/tracer.c
@@ -15,6 +15,7 @@
 
 #include "config.h"
 #include "database.h"
+#include "ptrace_utils.h"
 
 
 #define PROCESS_FREE        0
@@ -27,8 +28,8 @@ struct Process {
     int status;
     int in_syscall;
     int current_syscall;
-    size_t retvalue;
-    size_t params[6];
+    register_type retvalue;
+    register_type params[6];
     void *syscall_info;
 };
 
@@ -135,17 +136,15 @@ int trace_handle_syscall(struct Process *process)
 #endif
     if(process->in_syscall && syscall == SYS_open)
     {
-        /* FIXME : this cast doesn't look too safe */
-        int ret = process->retvalue;
         unsigned int mode;
-        char *pathname = tracee_strdup(pid, process->params[0]);
+        char *pathname = tracee_strdup(pid, (void*)process->params[0]);
 #ifdef DEBUG
         fprintf(stderr, "open(\"%s\") = %d (%s)\n", pathname, ret,
                 (ret >= 0)?"success":"failure");
 #endif
-        if(ret >= 0)
+        if(process->retvalue >= 0)
         {
-            mode = flags2mode((int)process->params[1]);
+            mode = flags2mode(process->params[1]);
             if(db_add_file_open(process->identifier,
                                 pathname,
                                 mode) != 0)
@@ -162,8 +161,8 @@ int trace_handle_syscall(struct Process *process)
 #ifdef DEBUG
         fprintf(stderr, "Entering execve, getting arguments...\n");
 #endif
-        execi->binary = tracee_strdup(pid, process->params[0]);
-        execi->argv = tracee_strarraydup(pid, process->params[1]);
+        execi->binary = tracee_strdup(pid, (void*)process->params[0]);
+        execi->argv = tracee_strarraydup(pid, (void*)process->params[1]);
 #ifdef DEBUG
         fprintf(stderr, "Got arguments:\n  binary=%s\n  argv:\n",
                 execi->binary);
@@ -182,10 +181,8 @@ int trace_handle_syscall(struct Process *process)
     }
     else if(process->in_syscall && syscall == SYS_execve)
     {
-        /* FIXME : this cast doesn't look too safe */
-        int ret = process->retvalue;
         struct ExecveInfo *execi = process->syscall_info;
-        if(ret >= 0)
+        if(process->retvalue >= 0)
         {
             /* Note: exec->argv needs cast to suppress a bogus GCC warning
              * While conversion from char** to const char** is invalid,


### PR DESCRIPTION
Make the code more type-safe; use pointer types to represent pointers (even if pointing to another process's memory space).

Also, check type sizes.
