### PR TITLE
Symlinks handling

### DIFF
--- a/reprozip/pack.py
+++ b/reprozip/pack.py
@@ -13,6 +13,48 @@ Package = namedtuple('Package', ['name', 'version', 'files', 'packfiles',
                                  'size'])
 
 
+def find_all_links(filename, files=None):
+    """Dereferences symlinks from a path, returning them plus the final target.
+
+    Example:
+        /
+            a -> b
+            b
+                g -> c
+                c -> ../a/d
+                d
+                    e -> /f
+            f
+    >>> find_all_links('/a/g/e')
+    ['/a', '/b/c', '/b/g', '/b/d/e', '/f']
+    """
+    if files is None:
+        files = set()
+    # We assume that filename is an abspath, so we can just split on os.sep
+    path = '/'
+    for c in filename.split(os.sep)[1:]:
+        # At this point, path is a canonical path, and all links in it have
+        # been resolved
+
+        # We add the next path component
+        path = os.path.join(path, c)
+
+        # That component is possibly a link
+        if os.path.islink(path):
+            target = os.path.abspath(os.path.join(os.path.dirname(path),
+                                                  os.readlink(path)))
+            # Here, target might contain a number of symlinks
+            if target not in files:
+                # Adds the link itself
+                files.add(path)
+
+                # Recurse on this new path
+                find_all_links(target, files)
+            # Restores the invariant; realpath might resolve several links here
+            path = os.path.realpath(path)
+    return list(files) + [path]
+
+
 def pack(target, directory):
     """Main function for the pack subcommand.
     """
@@ -60,12 +102,8 @@ def pack(target, directory):
         if pkg.packfiles:
             logging.info("Adding files from package %s..." % pkg.name)
             for f in pkg.files:
-                t = f.path
-                logging.debug(t)
-                tar.add(t)
-                while os.path.islink(t):
-                    t = os.path.join(os.path.dirname(t),
-                                     os.readlink(t))
+                # This path is absolute, but not canonical
+                for t in find_all_links(f.path):
                     logging.debug(t)
                     tar.add(t)
         else:


### PR DESCRIPTION
See [code from reprozip](https://github.com/fchirigati/reprozip/blob/master/reprozip/pack/system_tap/parse_stap_out.py#L581)

I correctly create chains of symlinks if a link is referenced, so that its target(s) are created as well in the pack. However, links might be walked over elsewhere in the path to the file; these links need to exist in the pack as well.
