### PR TITLE
Windows installer

### DIFF
--- a/scripts/windows/input/reprounzip.bat
+++ b/scripts/windows/input/reprounzip.bat
@@ -1,0 +1,2 @@
+@echo off
+"%~dp0\python2.7\Scripts\reprounzip.exe" %*

--- a/scripts/windows/reprounzip.iss
+++ b/scripts/windows/reprounzip.iss
@@ -13,3 +13,4 @@ OutputDir=output
 [Files]
 ; Base Python files
 Source: C:\Python2.7\*; DestDir: {app}\python2.7; Flags: recursesubdirs
+Source: input\reprounzip.bat; DestDir: {app}


### PR DESCRIPTION
A one-click installer for Windows.

Doesn't include Vagrant, VirtualBox or Docker.

We probably don't need to bundle the whole of Python, but I don't care enough to figure out what can be removed.
