### PR TITLE
Restores hostname

### DIFF
--- a/reprounzip-docker/reprounzip/unpackers/docker.py
+++ b/reprounzip-docker/reprounzip/unpackers/docker.py
@@ -245,6 +245,8 @@ def docker_run(args):
     # Name of new container
     container = make_unique_name(b'reprounzip_run_')
 
+    hostname = runs[selected_runs[0]].get('hostname', 'reprounzip')
+
     cmds = []
     for run_number in selected_runs:
         run = runs[run_number]
@@ -269,6 +271,7 @@ def docker_run(args):
     # Run command in container
     logging.info("Starting container %s", container.decode('ascii'))
     retcode = subprocess.call(['docker', 'run', b'--name=' + container,
+                               '-h', hostname,
                                '-i', '-t', image,
                                '/bin/sh', '-c', cmds])
     sys.stderr.write("\n*** Command finished, status: %d\n" % retcode)

--- a/reprounzip-vagrant/reprounzip/unpackers/vagrant/__init__.py
+++ b/reprounzip-vagrant/reprounzip/unpackers/vagrant/__init__.py
@@ -424,6 +424,8 @@ def vagrant_run(args):
 
     selected_runs = get_runs(runs, args.run, cmdline)
 
+    hostname = runs[selected_runs[0]].get('hostname', 'reprounzip')
+
     cmds = []
     for run_number in selected_runs:
         run = runs[run_number]
@@ -450,6 +452,13 @@ def vagrant_run(args):
             cmd = 'sudo -u \'#%d\' sh -c %s' % (uid, shell_escape(cmd))
         cmds.append(cmd)
     cmds = ' && '.join(cmds)
+    # Sets the hostname to the original experiment's machine's
+    # FIXME: not reentrant: this restores the Vagrant machine's hostname after
+    # the run, which might cause issues if several "reprounzip vagrant run" are
+    # running at once
+    cmds = ('OLD_HOSTNAME=$(/bin/hostname); /bin/hostname %s; ' % hostname +
+            cmds +
+            '; RES=$?; /bin/hostname "$OLD_HOSTNAME"; exit $RES')
     cmds = '/usr/bin/sudo /bin/sh -c %s' % shell_escape(cmds)
 
     # Gets vagrant SSH parameters


### PR DESCRIPTION
For Vagrant, set the hostname to the original experiment's machine's.

This is needed for X11 support (#96), so that we know what the hostname is. With other unpackers (except Docker), we also know what the hostname is since it's the local machine's.