### PR TITLE
X11 support

### DIFF
--- a/reprounzip-vagrant/reprounzip/unpackers/vagrant/__init__.py
+++ b/reprounzip-vagrant/reprounzip/unpackers/vagrant/__init__.py
@@ -350,7 +350,7 @@ def vagrant_run(args):
     hostname = runs[selected_runs[0]].get('hostname', 'reprounzip')
 
     # X11 handler
-    x11 = X11Handler(args.x11, hostname, args.x11_display)
+    x11 = X11Handler(args.x11, ('local', hostname), args.x11_display)
 
     cmds = []
     for run_number in selected_runs:

--- a/reprounzip-vagrant/reprounzip/unpackers/vagrant/__init__.py
+++ b/reprounzip-vagrant/reprounzip/unpackers/vagrant/__init__.py
@@ -350,7 +350,7 @@ def vagrant_run(args):
     hostname = runs[selected_runs[0]].get('hostname', 'reprounzip')
 
     # X11 handler
-    x11 = X11Handler(args.x11, args.x11_display)
+    x11 = X11Handler(args.x11, hostname, args.x11_display)
 
     cmds = []
     for run_number in selected_runs:

--- a/reprounzip-vagrant/reprounzip/unpackers/vagrant/run_command.py
+++ b/reprounzip-vagrant/reprounzip/unpackers/vagrant/run_command.py
@@ -1,0 +1,97 @@
+# Copyright (C) 2014-2015 New York University
+# This file is part of ReproZip which is released under the Revised BSD License
+# See file LICENSE for full license details.
+
+"""SSH command runner.
+
+This contains `run_interactive()`, used to run a command via SSH.
+"""
+
+import logging
+import os
+import paramiko
+from paramiko.client import MissingHostKeyPolicy
+import subprocess
+import sys
+
+from reprounzip.common import record_usage
+from reprounzip.unpackers.vagrant.interaction import interactive_shell
+from reprounzip.utils import irange
+
+
+class IgnoreMissingKey(MissingHostKeyPolicy):
+    """Policy that just ignores missing SSH host keys.
+
+    We are connecting to vagrant, checking the host doesn't make sense, and
+    accepting keys permanently is a security risk.
+    """
+    def missing_host_key(self, client, hostname, key):
+        pass
+
+
+def find_ssh_executable(name='ssh'):
+    exts = os.environ.get('PATHEXT', '').split(os.pathsep)
+    dirs = list(os.environ.get('PATH', '').split(os.pathsep))
+    par, join = os.path.dirname, os.path.join
+    # executable might be bin/python or ReproUnzip\python
+    # or ReproUnzip\Python27\python or ReproUnzip\Python27\Scripts\something
+    loc = par(sys.executable)
+    local_dirs = []
+    for i in irange(3):
+        local_dirs.extend([loc, join(loc, 'ssh')])
+        loc = par(loc)
+    for pathdir in local_dirs + dirs:
+        for ext in exts:
+            fullpath = os.path.join(pathdir, name + ext)
+            if os.path.isfile(fullpath):
+                return fullpath
+    return None
+
+
+def run_interactive(ssh_info, interactive, cmds, request_pty):
+    if interactive:
+        ssh_exe = find_ssh_executable()
+    else:
+        ssh_exe = None
+
+    if interactive and ssh_exe:
+        record_usage(vagrant_ssh='ssh')
+        return subprocess.call(
+                [ssh_exe,
+                 '-t' if request_pty else '-T',  # Force allocation of PTY
+                 '-o', 'StrictHostKeyChecking=no',  # Silently accept host keys
+                 '-o', 'UserKnownHostsFile=/dev/null',  # Don't store host keys
+                 '-i', ssh_info['key_filename'],
+                 '-p', '%d' % ssh_info['port'],
+                 '%s@%s' % (ssh_info['username'],
+                            ssh_info['hostname']),
+                 cmds])
+    else:
+        record_usage(vagrant_ssh='interactive' if interactive else 'simple')
+        # Connects to the machine
+        ssh = paramiko.SSHClient()
+        ssh.set_missing_host_key_policy(IgnoreMissingKey())
+        ssh.connect(**ssh_info)
+
+        chan = ssh.get_transport().open_session()
+        if request_pty:
+            chan.get_pty()
+
+        # Execute command
+        logging.info("Connected via SSH, running command...")
+        chan.exec_command(cmds)
+
+        # Get output
+        if interactive:
+            interactive_shell(chan)
+        else:
+            chan.shutdown_write()
+            while True:
+                data = chan.recv(1024)
+                if len(data) == 0:
+                    break
+                sys.stdout.buffer.write(data)
+                sys.stdout.flush()
+        retcode = chan.recv_exit_status()
+        ssh.close()
+        return retcode

--- a/reprounzip-vagrant/reprounzip/unpackers/vagrant/run_command.py
+++ b/reprounzip-vagrant/reprounzip/unpackers/vagrant/run_command.py
@@ -136,8 +136,10 @@ def run_interactive(ssh_info, interactive, cmd, request_pty, forwarded_ports):
         ssh.connect(**ssh_info)
 
         # Starts forwarding
+        forwarders = []
         for remote_port, connector in forwarded_ports:
-            SSHForwarder(ssh.get_transport(), remote_port, connector)
+            forwarders.append(
+                    SSHForwarder(ssh.get_transport(), remote_port, connector))
 
         chan = ssh.get_transport().open_session()
         if request_pty:

--- a/reprounzip/reprounzip/unpackers/common/__init__.py
+++ b/reprounzip/reprounzip/unpackers/common/__init__.py
@@ -13,22 +13,24 @@ from __future__ import unicode_literals
 import functools
 import logging
 import os
-import platform
 import random
 from rpaths import PosixPath, Path
 import string
-import subprocess
 import sys
 import tarfile
 
 import reprounzip.common
-from reprounzip.utils import irange, itervalues
+from reprounzip.utils import irange
+from reprounzip.unpackers.common.packages import THIS_DISTRIBUTION, \
+    PKG_NOT_INSTALLED, select_installer
 
 
-THIS_DISTRIBUTION = platform.linux_distribution()[0].lower()
-
-
-PKG_NOT_INSTALLED = "(not installed)"
+__all__ = ['THIS_DISTRIBUTION', 'PKG_NOT_INSTALLED', 'select_installer',
+           'COMPAT_OK, COMPAT_NO, COMPAT_MAYBE',
+           'UsageError',
+           'composite_action', 'target_must_exist', 'unique_names',
+           'make_unique_name', 'shell_escape', 'load_config', 'busybox_url',
+           'join_root', 'FileUploader', 'FileDownloader', 'get_runs']
 
 
 COMPAT_OK = 0
@@ -125,102 +127,6 @@ def load_config(pack):
         tmp.rmtree()
 
     return ret
-
-
-class AptInstaller(object):
-    """Installer for deb-based systems (Debian, Ubuntu).
-    """
-    def __init__(self, binary):
-        self.bin = binary
-
-    def install(self, packages, assume_yes=False):
-        # Installs
-        options = []
-        if assume_yes:
-            options.append('-y')
-        required_pkgs = set(pkg.name for pkg in packages)
-        r = subprocess.call([self.bin, 'install'] +
-                            options + list(required_pkgs))
-
-        # Checks on packages
-        pkgs_status = self.get_packages_info(packages)
-        for pkg, status in itervalues(pkgs_status):
-            if status is not None:
-                required_pkgs.discard(pkg.name)
-        if required_pkgs:
-            logging.error("Error: some packages could not be installed:%s",
-                          ''.join("\n    %s" % pkg for pkg in required_pkgs))
-
-        return r, pkgs_status
-
-    @staticmethod
-    def get_packages_info(packages):
-        if not packages:
-            return {}
-
-        p = subprocess.Popen(['dpkg-query',
-                              '--showformat=${Package;-50}\t${Version}\n',
-                              '-W'] +
-                             [pkg.name for pkg in packages],
-                             stdout=subprocess.PIPE)
-        # name -> (pkg, installed_version)
-        pkgs_dict = dict((pkg.name, (pkg, PKG_NOT_INSTALLED))
-                         for pkg in packages)
-        try:
-            for l in p.stdout:
-                fields = l.split()
-                if len(fields) == 2:
-                    name = fields[0].decode('ascii')
-                    status = fields[1].decode('ascii')
-                else:
-                    name = fields[0].decode('ascii')
-                    status = PKG_NOT_INSTALLED
-                pkg, _ = pkgs_dict[name]
-                pkgs_dict[name] = pkg, status
-        finally:
-            p.wait()
-
-        return pkgs_dict
-
-    def update_script(self):
-        return '%s update' % self.bin
-
-    def install_script(self, packages):
-        return '%s install -y %s' % (self.bin,
-                                     ' '.join(pkg.name for pkg in packages))
-
-
-def select_installer(pack, runs, target_distribution=THIS_DISTRIBUTION):
-    """Selects the right package installer for a Linux distribution.
-    """
-    orig_distribution = runs[0]['distribution'][0].lower()
-
-    # Checks that the distributions match
-    if (set([orig_distribution, target_distribution]) ==
-            set(['ubuntu', 'debian'])):
-        # Packages are more or less the same on Debian and Ubuntu
-        logging.warning("Installing on %s but pack was generated on %s",
-                        target_distribution.capitalize(),
-                        orig_distribution.capitalize())
-    elif orig_distribution != target_distribution:
-        logging.error("Installing on %s but pack was generated on %s",
-                      target_distribution.capitalize(),
-                      orig_distribution.capitalize())
-        sys.exit(1)
-
-    # Selects installation method
-    if target_distribution == 'ubuntu':
-        installer = AptInstaller('apt-get')
-    elif target_distribution == 'debian':
-        # aptitude is not installed by default, so use apt-get here too
-        installer = AptInstaller('apt-get')
-    else:
-        logging.critical("Your current distribution, \"%s\", is not "
-                         "supported",
-                         (target_distribution or "(unknown)").capitalize())
-        sys.exit(1)
-
-    return installer
 
 
 def busybox_url(arch):

--- a/reprounzip/reprounzip/unpackers/common/packages.py
+++ b/reprounzip/reprounzip/unpackers/common/packages.py
@@ -1,0 +1,117 @@
+# Copyright (C) 2014-2015 New York University
+# This file is part of ReproZip which is released under the Revised BSD License
+# See file LICENSE for full license details.
+
+"""Utility functions dealing with package managers.
+"""
+
+from __future__ import unicode_literals
+
+import logging
+import platform
+import subprocess
+import sys
+
+from reprounzip.utils import itervalues
+
+
+THIS_DISTRIBUTION = platform.linux_distribution()[0].lower()
+
+
+PKG_NOT_INSTALLED = "(not installed)"
+
+
+class AptInstaller(object):
+    """Installer for deb-based systems (Debian, Ubuntu).
+    """
+    def __init__(self, binary):
+        self.bin = binary
+
+    def install(self, packages, assume_yes=False):
+        # Installs
+        options = []
+        if assume_yes:
+            options.append('-y')
+        required_pkgs = set(pkg.name for pkg in packages)
+        r = subprocess.call([self.bin, 'install'] +
+                            options + list(required_pkgs))
+
+        # Checks on packages
+        pkgs_status = self.get_packages_info(packages)
+        for pkg, status in itervalues(pkgs_status):
+            if status is not None:
+                required_pkgs.discard(pkg.name)
+        if required_pkgs:
+            logging.error("Error: some packages could not be installed:%s",
+                          ''.join("\n    %s" % pkg for pkg in required_pkgs))
+
+        return r, pkgs_status
+
+    @staticmethod
+    def get_packages_info(packages):
+        if not packages:
+            return {}
+
+        p = subprocess.Popen(['dpkg-query',
+                              '--showformat=${Package;-50}\t${Version}\n',
+                              '-W'] +
+                             [pkg.name for pkg in packages],
+                             stdout=subprocess.PIPE)
+        # name -> (pkg, installed_version)
+        pkgs_dict = dict((pkg.name, (pkg, PKG_NOT_INSTALLED))
+                         for pkg in packages)
+        try:
+            for l in p.stdout:
+                fields = l.split()
+                if len(fields) == 2:
+                    name = fields[0].decode('ascii')
+                    status = fields[1].decode('ascii')
+                else:
+                    name = fields[0].decode('ascii')
+                    status = PKG_NOT_INSTALLED
+                pkg, _ = pkgs_dict[name]
+                pkgs_dict[name] = pkg, status
+        finally:
+            p.wait()
+
+        return pkgs_dict
+
+    def update_script(self):
+        return '%s update' % self.bin
+
+    def install_script(self, packages):
+        return '%s install -y %s' % (self.bin,
+                                     ' '.join(pkg.name for pkg in packages))
+
+
+def select_installer(pack, runs, target_distribution=THIS_DISTRIBUTION):
+    """Selects the right package installer for a Linux distribution.
+    """
+    orig_distribution = runs[0]['distribution'][0].lower()
+
+    # Checks that the distributions match
+    if (set([orig_distribution, target_distribution]) ==
+            set(['ubuntu', 'debian'])):
+        # Packages are more or less the same on Debian and Ubuntu
+        logging.warning("Installing on %s but pack was generated on %s",
+                        target_distribution.capitalize(),
+                        orig_distribution.capitalize())
+    elif orig_distribution != target_distribution:
+        logging.error("Installing on %s but pack was generated on %s",
+                      target_distribution.capitalize(),
+                      orig_distribution.capitalize())
+        sys.exit(1)
+
+    # Selects installation method
+    if target_distribution == 'ubuntu':
+        installer = AptInstaller('apt-get')
+    elif target_distribution == 'debian':
+        # aptitude is not installed by default, so use apt-get here too
+        installer = AptInstaller('apt-get')
+    else:
+        logging.critical("Your current distribution, \"%s\", is not "
+                         "supported",
+                         (target_distribution or "(unknown)").capitalize())
+        sys.exit(1)
+
+    return installer

--- a/reprounzip/reprounzip/unpackers/common/x11.py
+++ b/reprounzip/reprounzip/unpackers/common/x11.py
@@ -7,7 +7,16 @@
 
 from __future__ import unicode_literals
 
+import contextlib
+import logging
+import os
+from rpaths import Path, PosixPath
+import select
+import socket
 import struct
+import threading
+
+from reprounzip.utils import iteritems
 
 
 # #include <X11/Xauth.h>
@@ -78,3 +87,283 @@ class Xauth(object):
                 ascii(self.name) +
                 _write_short(len(self.data)) +
                 ascii(self.data))
+
+
+class X11Handler(object):
+    """X11 handler.
+
+    This selects a way to connect to the local X server and an authentication
+    mechanism. If provides `fix_env()` to set the X environment variable for
+    the experiment, `init_cmds` to setup X before running the experiment's main
+    commands, and `port_forward` which describes the reverse port tunnels from
+    the experiment to the local X server.
+    """
+    DISPLAY_NUMBER = 15
+
+    SOCK2X = {socket.AF_INET: Xauth.FAMILY_INTERNET,
+              socket.AF_INET6: Xauth.FAMILY_INTERNET6}
+    X2SOCK = dict((v, k) for k, v in iteritems(SOCK2X))
+
+    def __init__(self, enabled, display=None):
+        self.enabled = enabled
+        if not self.enabled:
+            return
+
+        self.xauth = PosixPath('/.reprounzip_xauthority')
+        self.display = display if display is not None else self.DISPLAY_NUMBER
+        logging.debug("X11 support enabled; will create Xauthority file %s "
+                      "for experiment. Display number is %d", self.xauth,
+                      self.display)
+
+        # List of addresses that match the $DISPLAY variable
+        possible, tcp_portnum = self._locate_display()
+
+        if ('XAUTHORITY' in os.environ and
+                Path(os.environ['XAUTHORITY']).is_file()):
+            xauthority = Path(os.environ['XAUTHORITY'])
+        # Note: I'm assuming here that Xauthority has no XDG support
+        else:
+            xauthority = Path('~').expand_user() / '.Xauthority'
+
+        # Read Xauthority file
+        xauth_entries = {}
+        if xauthority.is_file():
+            with xauthority.open('rb') as fp:
+                fp.seek(0, os.SEEK_END)
+                size = fp.tell()
+                fp.seek(0, os.SEEK_SET)
+                while fp.tell() < size:
+                    entry = Xauth.from_file(fp)
+                    if entry.name == 'MIT-MAGIC-COOKIE-1':
+                        if entry.family == Xauth.FAMILY_LOCAL:
+                            xauth_entries[(entry.family, None)] = entry
+                        elif (entry.family == Xauth.FAMILY_INTERNET or
+                                entry.family == Xauth.FAMILY_INTERNET6):
+                            xauth_entries[(entry.family,
+                                           entry.address)] = entry
+        # FIXME: this completely ignores display numbers
+
+        logging.debug("Possible X endpoints: %s", (possible,))
+
+        # Select socket and authentication cookie
+        self.xauth_record = None
+        self.connection_info = None
+        for family, address in possible:
+            # Checks that we have a cookie
+            entry = family, (None if family is Xauth.FAMILY_LOCAL else address)
+            if entry not in xauth_entries:
+                continue
+            if family == Xauth.FAMILY_LOCAL and hasattr(socket, 'AF_UNIX'):
+                # Checks that the socket exists
+                if not Path(address).exists():
+                    continue
+                self.connection_info = (socket.AF_UNIX, socket.SOCK_STREAM,
+                                        address)
+                self.xauth_record = xauth_entries[(family, None)]
+                logging.debug("Will connect to local X display via UNIX "
+                              "socket %s", address)
+                break
+            else:
+                # Checks that we have a cookie
+                family = self.X2SOCK[family]
+                self.connection_info = (family, socket.SOCK_STREAM,
+                                        (address, tcp_portnum))
+                self.xauth_record = xauth_entries[(family, address)]
+                logging.debug("Will connect to X display %s:%d via %s/TCP",
+                              address, tcp_portnum,
+                              "IPv6" if family == socket.AF_INET6 else "IPv4")
+                break
+
+        # Didn't find an Xauthority record -- assume no authentication is
+        # needed, but still set self.connection_info
+        if self.connection_info is None:
+            for family, address in possible:
+                # Only try UNIX sockets, we'll use 127.0.0.1 otherwise
+                if family == Xauth.FAMILY_LOCAL:
+                    if not hasattr(socket, 'AF_UNIX'):
+                        continue
+                    self.connection_info = (socket.AF_UNIX, socket.SOCK_STREAM,
+                                            address)
+                    logging.debug("Will connect to X display via UNIX socket "
+                                  "%s, no authentication", address)
+                    break
+            else:
+                self.connection_info = (socket.AF_INET, socket.SOCK_STREAM,
+                                        ('127.0.0.1', tcp_portnum))
+                logging.debug(
+                        "Will connect to X display 127.0.0.1:%d via IPv4/TCP, "
+                        "no authentication", tcp_portnum)
+
+        if self.connection_info is None:
+            raise RuntimeError("Couldn't determine how to connect to local X "
+                               "server, DISPLAY is %s" % (
+                                    repr(os.environ['DISPLAY'])
+                                    if 'DISPLAY' is os.environ
+                                    else 'not set'))
+
+    @classmethod
+    def _locate_display(cls):
+        """Reads $DISPLAY and figures out possible sockets.
+        """
+        # We default to ":0", Xming for instance doesn't set $DISPLAY
+        display = os.environ.get('DISPLAY', ':0')
+
+        # It might be the full path to a UNIX socket
+        if display.startswith('/'):
+            return [(Xauth.FAMILY_LOCAL, display)], None
+
+        local_addr, local_display = display.rsplit(':', 1)
+        local_display = int(local_display.split('.', 1)[0])
+
+        # Let's order the socket families: IPv4 first, then v6, then others
+        def sort_families(gai, order={socket.AF_INET: 0, socket.AF_INET6: 1}):
+            return sorted(gai, key=lambda x: order.get(x[0], 999999))
+
+        # Network addresses of the local machine
+        local_addresses = []
+        port_num = 6000 + local_display
+        for family, socktype, proto, canonname, sockaddr in \
+                sort_families(socket.getaddrinfo(socket.gethostname(), 6000)):
+            try:
+                family = cls.SOCK2X[family]
+            except KeyError:
+                continue
+            local_addresses.append((family, sockaddr[0]))
+
+        logging.debug("Local addresses: %s", (local_addresses,))
+
+        # Determine possible addresses for $DISPLAY
+        if not local_addr:
+            possible = [(Xauth.FAMILY_LOCAL,
+                         '/tmp/.X11-unix/X%d' % local_display)]
+            possible += local_addresses
+        else:
+            local_possible = False
+            possible = []
+            for family, socktype, proto, canonname, sockaddr in \
+                    sort_families(socket.getaddrinfo(local_addr, 6000)):
+                try:
+                    family = cls.SOCK2X[family]
+                except KeyError:
+                    continue
+                if (family, sockaddr[0]) in local_addresses:
+                    local_possible = True
+                possible.append(family, sockaddr[0])
+            if local_possible:
+                possible = [(Xauth.FAMILY_LOCAL,
+                             '/tmp/.X11-unix/X%d' % local_display)] + possible
+
+        return possible, port_num
+
+    @property
+    def port_forward(self):
+        """Builds the port forwarding info, for `run_interactive()`.
+
+        Just requests port 6000 on the remote host to be forwarded to the X
+        socket identified by `self.connection_info`.
+        """
+        if not self.enabled:
+            return []
+
+        @contextlib.contextmanager
+        def connect(src_addr):
+            logging.info("Got remote X connection from %s", (src_addr,))
+            logging.debug("Connecting to X server: %s",
+                          (self.connection_info,))
+            sock = socket.socket(*self.connection_info[:2])
+            sock.connect(self.connection_info[2])
+            yield sock
+            sock.close()
+            logging.info("X connection from %s closed", (src_addr,))
+
+        return [(6000 + self.display, connect)]
+
+    def fix_env(self, env):
+        """Sets ``$XAUTHORITY`` and ``$DISPLAY`` in the environment.
+        """
+        if not self.enabled:
+            return env
+        new_env = dict(env)
+        new_env['XAUTHORITY'] = str(self.xauth)
+        new_env['DISPLAY'] = '127.0.0.1:%d' % self.display
+        return new_env
+
+    @property
+    def init_cmds(self):
+        """Gets the commands to setup X on the server before the experiment.
+        """
+        if not self.enabled or self.xauth_record is None:
+            return []
+
+        xauth_record = Xauth(Xauth.FAMILY_LOCAL,
+                             'localhost',  # FIXME: this HAS to be the hostname
+                             self.display,
+                             self.xauth_record.name,
+                             self.xauth_record.data)
+        buf = xauth_record.as_bytes()
+        xauth = ''.join(('\\x%02x' % ord(buf[i:i + 1]))
+                        for i in xrange(len(buf)))
+        return ['echo -ne "%s" > %s' % (xauth, self.xauth)]
+
+
+class BaseForwarder(object):
+    """Accepts connections and forwards to the given connector object.
+
+    The `connector` is a function which takes the address of remote process
+    connecting on this ends, and gives out a socket object that is the second
+    endpoint of the tunnel. The socket object must provide ``recv()``,
+    ``sendall()`` and ``close()``.
+
+    Abstract class, implementations will provide actual ways to accept
+    connections.
+    """
+    def __init__(self, connector):
+        self.connector = connector
+
+    def _forward(self, client, src_addr):
+        with self.connector(src_addr) as local_connection:
+            local_fd = local_connection.fileno()
+            client_fd = client.fileno()
+            while True:
+                r, w, x = select.select([local_fd, client_fd], [], [])
+                if local_fd in r:
+                    data = local_connection.recv(4096)
+                    print("> %d" % len(data))
+                    if not data:
+                        break
+                    client.sendall(data)
+                elif client_fd in r:
+                    data = client.recv(4096)
+                    print("< %d" % len(data))
+                    if not data:
+                        break
+                    local_connection.sendall(data)
+            client.close()
+
+
+class LocalForwarder(BaseForwarder):
+    """Listens on a random port and forwards to the given connector object.
+
+    The `connector` is a function which takes the address of remote process
+    connecting on this ends, and gives out a socket object that is the second
+    endpoint of the tunnel. The socket object must provide ``recv()``,
+    ``sendall()`` and ``close()``.
+    """
+    def __init__(self, connector, local_port=None):
+        BaseForwarder.__init__(self, connector)
+        server = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+        server.bind(('', local_port or 0))
+        self.local_port = server.getsockname()[1]
+        server.listen(5)
+
+        t = threading.Thread(target=self._accept, args=(server,))
+        t.setDaemon(True)
+        t.start()
+
+    def _accept(self, server):
+        while True:
+            client, src_addr = server.accept()
+            t = threading.Thread(target=self._forward,
+                                 args=(client, src_addr))
+            t.setDaemon(True)
+            t.start()

--- a/reprounzip/reprounzip/unpackers/common/x11.py
+++ b/reprounzip/reprounzip/unpackers/common/x11.py
@@ -263,7 +263,7 @@ class X11Handler(object):
     def port_forward(self):
         """Builds the port forwarding info, for `run_interactive()`.
 
-        Just requests port 6000 on the remote host to be forwarded to the X
+        Just requests port 6015 on the remote host to be forwarded to the X
         socket identified by `self.connection_info`.
         """
         if not self.enabled:

--- a/reprounzip/reprounzip/unpackers/common/x11.py
+++ b/reprounzip/reprounzip/unpackers/common/x11.py
@@ -1,0 +1,80 @@
+# Copyright (C) 2014-2015 New York University
+# This file is part of ReproZip which is released under the Revised BSD License
+# See file LICENSE for full license details.
+
+"""Utility functions dealing with X servers.
+"""
+
+from __future__ import unicode_literals
+
+import struct
+
+
+# #include <X11/Xauth.h>
+#
+# typedef struct xauth {
+#        unsigned short  family;
+#        unsigned short  address_length;
+#        char    *address;
+#        unsigned short  number_length;
+#        char    *number;
+#        unsigned short  name_length;
+#        char    *name;
+#        unsigned short  data_length;
+#        char    *data;
+# } Xauth;
+
+
+_read_short = lambda fp: struct.unpack('>H', fp.read(2))[0]
+_write_short = lambda i: struct.pack('>H', i)
+
+
+def ascii(s):
+    if isinstance(s, bytes):
+        return s
+    else:
+        return s.encode('ascii')
+
+
+class Xauth(object):
+    """A record in an Xauthority file.
+    """
+    FAMILY_LOCAL = 256
+    FAMILY_INTERNET = 0
+    FAMILY_DECNET = 1
+    FAMILY_CHAOS = 2
+    FAMILY_INTERNET6 = 6
+    FAMILY_SERVERINTERPRETED = 5
+
+    def __init__(self, family, address, number, name, data):
+        self.family = family
+        self.address = address
+        self.number = number
+        self.name = name
+        self.data = data
+
+    @classmethod
+    def from_file(cls, fp):
+        family = _read_short(fp)
+        address_length = _read_short(fp)
+        address = fp.read(address_length)
+        number_length = _read_short(fp)
+        number = int(fp.read(number_length))
+        name_length = _read_short(fp)
+        name = fp.read(name_length)
+        data_length = _read_short(fp)
+        data = fp.read(data_length)
+
+        return cls(family, address, number, name, data)
+
+    def as_bytes(self):
+        number = ('%d' % self.number).encode('ascii')
+        return (_write_short(self.family) +
+                _write_short(len(self.address)) +
+                ascii(self.address) +
+                _write_short(len(number)) +
+                number +
+                _write_short(len(self.name)) +
+                ascii(self.name) +
+                _write_short(len(self.data)) +
+                ascii(self.data))

--- a/reprounzip/reprounzip/unpackers/common/x11.py
+++ b/reprounzip/reprounzip/unpackers/common/x11.py
@@ -104,10 +104,12 @@ class X11Handler(object):
               socket.AF_INET6: Xauth.FAMILY_INTERNET6}
     X2SOCK = dict((v, k) for k, v in iteritems(SOCK2X))
 
-    def __init__(self, enabled, display=None):
+    def __init__(self, enabled, hostname, display=None):
         self.enabled = enabled
         if not self.enabled:
             return
+
+        self.hostname = hostname
 
         self.xauth = PosixPath('/.reprounzip_xauthority')
         self.display = display if display is not None else self.DISPLAY_NUMBER
@@ -296,7 +298,7 @@ class X11Handler(object):
             return []
 
         xauth_record = Xauth(Xauth.FAMILY_LOCAL,
-                             'localhost',  # FIXME: this HAS to be the hostname
+                             self.hostname,
                              self.display,
                              self.xauth_record.name,
                              self.xauth_record.data)

--- a/reprounzip/reprounzip/unpackers/common/x11.py
+++ b/reprounzip/reprounzip/unpackers/common/x11.py
@@ -332,13 +332,11 @@ class BaseForwarder(object):
                 r, w, x = select.select([local_fd, client_fd], [], [])
                 if local_fd in r:
                     data = local_connection.recv(4096)
-                    print("> %d" % len(data))
                     if not data:
                         break
                     client.sendall(data)
                 elif client_fd in r:
                     data = client.recv(4096)
-                    print("< %d" % len(data))
                     if not data:
                         break
                     local_connection.sendall(data)

--- a/reprounzip/reprounzip/unpackers/default.py
+++ b/reprounzip/reprounzip/unpackers/default.py
@@ -521,7 +521,8 @@ def chroot_run(args):
     root = target / 'root'
 
     # X11 handler
-    x11 = X11Handler(args.x11, socket.gethostname(), args.x11_display)
+    x11 = X11Handler(args.x11, ('local', socket.gethostname()),
+                     args.x11_display)
 
     cmds = []
     for run_number in selected_runs:

--- a/reprounzip/reprounzip/unpackers/default.py
+++ b/reprounzip/reprounzip/unpackers/default.py
@@ -32,6 +32,7 @@ from reprounzip.unpackers.common import THIS_DISTRIBUTION, PKG_NOT_INSTALLED, \
     COMPAT_OK, COMPAT_NO, target_must_exist, shell_escape, load_config, \
     select_installer, busybox_url, join_root, FileUploader, FileDownloader, \
     get_runs
+from reprounzip.unpackers.common.x11 import X11Handler, LocalForwarder
 from reprounzip.utils import unicode_, irange, iteritems, itervalues, \
     make_dir_writable, rmtree_fixed, download_file
 
@@ -518,13 +519,17 @@ def chroot_run(args):
 
     root = target / 'root'
 
+    # X11 handler
+    x11 = X11Handler(args.x11, args.x11_display)
+
     cmds = []
     for run_number in selected_runs:
         run = runs[run_number]
         cmd = 'cd %s && ' % shell_escape(run['workingdir'])
         cmd += '/usr/bin/env -i '
+        environ = x11.fix_env(run['environ'])
         cmd += ' '.join('%s=%s' % (k, shell_escape(v))
-                        for k, v in iteritems(run['environ']))
+                        for k, v in iteritems(environ))
         cmd += ' '
         # FIXME : Use exec -a or something if binary != argv[0]
         if cmdline is None:
@@ -539,7 +544,16 @@ def chroot_run(args):
                 shell_escape(unicode_(root)),
                 shell_escape(cmd))
         cmds.append(cmd)
+    cmds = ['chroot %s /bin/sh -c %s' % (shell_escape(unicode_(root)),
+                                         shell_escape(c))
+            for c in x11.init_cmds] + cmds
     cmds = ' && '.join(cmds)
+
+    # Starts forwarding
+    forwarders = []
+    for portnum, connector in x11.port_forward:
+        fwd = LocalForwarder(connector, portnum)
+        forwarders.append(fwd)
 
     signals.pre_run(target=target)
     retcode = subprocess.call(cmds, shell=True)
@@ -904,6 +918,14 @@ def setup_chroot(parser, **kwargs):
     parser_run.add_argument('run', default=None, nargs='?')
     parser_run.add_argument('--cmdline', nargs=argparse.REMAINDER,
                             help="Command line to run")
+    parser_run.add_argument('--enable-x11', action='store_true', default=False,
+                            dest='x11',
+                            help=("Enable X11 support (needs an X server on "
+                                  "the host"))
+    parser_run.add_argument('--x11-display', dest='x11_display',
+                            help=("Display number to use on the experiment "
+                                  "side (change the host display with the "
+                                  "DISPLAY environment variable)"))
     parser_run.set_defaults(func=chroot_run)
 
     # download

--- a/reprounzip/reprounzip/unpackers/default.py
+++ b/reprounzip/reprounzip/unpackers/default.py
@@ -22,6 +22,7 @@ import os
 import pickle
 import platform
 from rpaths import PosixPath, DefaultAbstractPath, Path
+import socket
 import subprocess
 import sys
 import tarfile
@@ -520,7 +521,7 @@ def chroot_run(args):
     root = target / 'root'
 
     # X11 handler
-    x11 = X11Handler(args.x11, args.x11_display)
+    x11 = X11Handler(args.x11, socket.gethostname(), args.x11_display)
 
     cmds = []
     for run_number in selected_runs:

--- a/reprounzip/setup.py
+++ b/reprounzip/setup.py
@@ -17,7 +17,8 @@ if sys.version_info < (2, 7):
     req.append('argparse')
 setup(name='reprounzip',
       version='0.5.1',
-      packages=['reprounzip', 'reprounzip.unpackers', 'reprounzip.plugins'],
+      packages=['reprounzip', 'reprounzip.unpackers',
+                'reprounzip.unpackers.common', 'reprounzip.plugins'],
       entry_points={
           'console_scripts': [
               'reprounzip = reprounzip.main:main'],


### PR DESCRIPTION
This allows the experiment to connect to the host's X server

It detects how to connect to the local X server (via `$DISPLAY`), extract the authentication cookie (from `.Xauthority`), injects that in the experiment, and establishes a tunnel from the experiment (in the VM for vagrant, on a different local TCP port for chroot) to the local X server (TCP or UNIX socket).

Implements #39

Uses #95 (setting the hostname in the Vagrant VM)