### PR TITLE
Use PTRACE_EVENT_EXEC instead of syscall return

### DIFF
--- a/reprozip/native/syscalls.c
+++ b/reprozip/native/syscalls.c
@@ -427,10 +427,7 @@ int syscall_execve_event(struct Process *process)
 static int syscall_execve_out(const char *name, struct Process *process,
                               unsigned int execve_syscall)
 {
-    if(process->retvalue.i >= 0)
-        log_debug(process->tid, "execve() successful");
-    else
-        log_debug(process->tid, "execve() failed");
+    log_debug(process->tid, "execve() failed");
     if(process->execve_info != NULL)
     {
         free_execve_info(process->execve_info);

--- a/reprozip/native/syscalls.c
+++ b/reprozip/native/syscalls.c
@@ -482,6 +482,7 @@ static int syscall_forking(const char *name, struct Process *process,
             /* Process hasn't been seen before (syscall returned first) */
             new_process = trace_get_empty_process();
             new_process->status = PROCSTAT_ALLOCATED;
+            new_process->flags = 0;
             /* New process gets a SIGSTOP, but we resume on attach */
             new_process->tid = new_tid;
             new_process->in_syscall = 0;

--- a/reprozip/native/syscalls.c
+++ b/reprozip/native/syscalls.c
@@ -366,7 +366,7 @@ static int syscall_execve_out(const char *name, struct Process *process,
         size_t i;
         for(i = 0; i < processes_size; ++i)
         {
-            if(processes[i]->status == PROCESS_ATTACHED
+            if(processes[i]->status == PROCSTAT_ATTACHED
              && processes[i]->threadgroup == process->threadgroup
              && processes[i]->in_syscall
              && processes[i]->current_syscall == (int)execve_syscall
@@ -458,7 +458,7 @@ static int syscall_forking(const char *name, struct Process *process,
         if(new_process != NULL)
         {
             /* Process has been seen before and options were set */
-            if(new_process->status != PROCESS_UNKNOWN)
+            if(new_process->status != PROCSTAT_UNKNOWN)
             {
                 /* LCOV_EXCL_START : internal error */
                 log_critical(new_tid,
@@ -467,7 +467,7 @@ static int syscall_forking(const char *name, struct Process *process,
                 return -1;
                 /* LCOV_EXCL_END */
             }
-            new_process->status = PROCESS_ATTACHED;
+            new_process->status = PROCSTAT_ATTACHED;
             ptrace(PTRACE_SYSCALL, new_process->tid, NULL, NULL);
             if(verbosity >= 2)
             {
@@ -481,7 +481,7 @@ static int syscall_forking(const char *name, struct Process *process,
         {
             /* Process hasn't been seen before (syscall returned first) */
             new_process = trace_get_empty_process();
-            new_process->status = PROCESS_ALLOCATED;
+            new_process->status = PROCSTAT_ALLOCATED;
             /* New process gets a SIGSTOP, but we resume on attach */
             new_process->tid = new_tid;
             new_process->in_syscall = 0;
@@ -953,7 +953,7 @@ int syscall_handle(struct Process *process)
             size_t i;
             for(i = 0; i < processes_size; ++i)
             {
-                if(processes[i]->status == PROCESS_ATTACHED
+                if(processes[i]->status == PROCSTAT_ATTACHED
                  && processes[i]->threadgroup == process->threadgroup
                  && processes[i]->in_syscall
                  && processes[i]->current_syscall == 59
@@ -973,7 +973,7 @@ int syscall_handle(struct Process *process)
             size_t i;
             for(i = 0; i < processes_size; ++i)
             {
-                if(processes[i]->status == PROCESS_ATTACHED
+                if(processes[i]->status == PROCSTAT_ATTACHED
                  && processes[i]->threadgroup == process->threadgroup
                  && processes[i]->in_syscall
                  && processes[i]->current_syscall == 11

--- a/reprozip/native/syscalls.h
+++ b/reprozip/native/syscalls.h
@@ -7,4 +7,6 @@ void syscall_build_table(void);
 
 int syscall_handle(struct Process *process);
 
+int syscall_execve_event(struct Process *process);
+
 #endif

--- a/reprozip/native/tracer.c
+++ b/reprozip/native/tracer.c
@@ -447,7 +447,7 @@ static int trace(pid_t first_proc, int *first_exit_code)
                 /* LCOV_EXCL_END */
             }
 #if defined(I386)
-            if(!process->in_syscall || regs.orig_eax >= 0)
+            if(!process->in_syscall)
                 process->current_syscall = regs.orig_eax;
             if(process->in_syscall)
                 get_i386_reg(&process->retvalue, regs.eax);
@@ -470,7 +470,7 @@ static int trace(pid_t first_proc, int *first_exit_code)
             {
                 /* 32 bit mode */
                 struct i386_regs *x86regs = (struct i386_regs*)&regs;
-                if(!process->in_syscall || x86regs->orig_eax >= 0)
+                if(!process->in_syscall)
                     process->current_syscall = x86regs->orig_eax;
                 if(process->in_syscall)
                     get_i386_reg(&process->retvalue, x86regs->eax);
@@ -488,7 +488,7 @@ static int trace(pid_t first_proc, int *first_exit_code)
             else
             {
                 /* 64 bit mode */
-                if(!process->in_syscall || regs.orig_rax >= 0)
+                if(!process->in_syscall)
                     process->current_syscall = regs.orig_rax;
                 if(process->in_syscall)
                     get_x86_64_reg(&process->retvalue, regs.rax);

--- a/reprozip/native/tracer.c
+++ b/reprozip/native/tracer.c
@@ -388,6 +388,7 @@ static int trace(pid_t first_proc, int *first_exit_code)
                 log_debug(tid, "process appeared");
             process = trace_get_empty_process();
             process->status = PROCSTAT_UNKNOWN;
+            process->flags = 0;
             process->tid = tid;
             process->threadgroup = NULL;
             process->in_syscall = 0;
@@ -623,8 +624,6 @@ static void trace_init(void)
             processes[i] = pool++;
             processes[i]->status = PROCSTAT_FREE;
             processes[i]->threadgroup = NULL;
-            processes[i]->in_syscall = 0;
-            processes[i]->current_syscall = -1;
             processes[i]->execve_info = NULL;
         }
     }
@@ -684,6 +683,7 @@ int fork_and_trace(const char *binary, int argc, char **argv,
     {
         struct Process *process = trace_get_empty_process();
         process->status = PROCSTAT_ALLOCATED; /* Not yet attached... */
+        process->flags = 0;
         /* We sent a SIGSTOP, but we resume on attach */
         process->tid = child;
         process->threadgroup = trace_new_threadgroup(child, get_wd());

--- a/reprozip/native/tracer.h
+++ b/reprozip/native/tracer.h
@@ -60,6 +60,8 @@ struct Process {
 #define MODE_X86_64         2   /* In x86_64 mode, syscalls might be native x64
                                  * or x32 */
 
+#define PROCFLAG_EXECD      1   /* Process is coming out of execve */
+
 /* FIXME : This is only exposed because of execve() workaround */
 extern struct Process **processes;
 extern size_t processes_size;

--- a/reprozip/native/tracer.h
+++ b/reprozip/native/tracer.h
@@ -42,6 +42,7 @@ struct Process {
     struct ThreadGroup *threadgroup;
     pid_t tid;
     int status;
+    unsigned int flags;
     int in_syscall;
     int current_syscall;
     register_type retvalue;

--- a/reprozip/native/tracer.h
+++ b/reprozip/native/tracer.h
@@ -49,10 +49,10 @@ struct Process {
     struct ExecveInfo *execve_info;
 };
 
-#define PROCESS_FREE        0   /* unallocated entry in table */
-#define PROCESS_ALLOCATED   1   /* fork() done but not yet attached */
-#define PROCESS_ATTACHED    2   /* running process */
-#define PROCESS_UNKNOWN     3   /* attached but no corresponding fork() call
+#define PROCSTAT_FREE       0   /* unallocated entry in table */
+#define PROCSTAT_ALLOCATED  1   /* fork() done but not yet attached */
+#define PROCSTAT_ATTACHED   2   /* running process */
+#define PROCSTAT_UNKNOWN    3   /* attached but no corresponding fork() call
                                  * has finished yet */
 
 #define MODE_I386           1

--- a/tests/functional.py
+++ b/tests/functional.py
@@ -348,6 +348,17 @@ def functional_tests(raise_warnings, interactive, run_vagrant, run_docker):
                for l in output.splitlines())
 
     # ########################################
+    # 'threads2' program: testrun
+    #
+
+    # Build
+    build('threads2', ['threads2.c'], ['-lpthread'])
+    # Trace
+    output = check_output(rpz + ['testrun', './threads2'], 'err')
+    assert any(b'successfully exec\'d /bin/echo' in l
+               for l in output.splitlines())
+
+    # ########################################
     # 'segv' program: testrun
     #
 

--- a/tests/threads.c
+++ b/tests/threads.c
@@ -13,20 +13,20 @@ void *func1(void *param)
 {
     static retvalue = 42;
     chdir("/bin");
-    usleep(100000);
+    usleep(300000);
     return &retvalue;
 }
 
 void *func23(void *param)
 {
-    usleep(500000);
+    usleep(1000000);
     return NULL;
 }
 
 void *func4(void *param)
 {
     char *argv[3] = {"echo", "42", NULL};
-    usleep(200000);
+    usleep(600000);
     execvp("./echo", argv);
     perror("execvp");
     return NULL;

--- a/tests/threads2.c
+++ b/tests/threads2.c
@@ -1,0 +1,51 @@
+/* threads2.c
+ *
+ * A second multithreaded program.
+ *
+ * usage: ./threads2
+ */
+
+#include <pthread.h>
+#include <stdio.h>
+
+
+int search(void)
+{
+    int i;
+    int sum = 0;
+    for(i = 0; sum != 10; ++i)
+    {
+        int a = 1, b = 1;
+        int j;
+        for(j = 1; j < i; ++j)
+        {
+            int c = a + b;
+            a = b;
+            b = c;
+        }
+        sum += b;
+    }
+    return i;
+}
+
+void *funcT(void *param)
+{
+    char *argv[3] = {"echo", "42", NULL};
+    usleep(200000);
+    execvp("/bin/echo", argv);
+    perror("execvp");
+    return NULL;
+}
+
+int main(void)
+{
+    int r;
+    pthread_t th;
+    pthread_create(&th, NULL, funcT, NULL);
+
+    r = search();
+    /* Won't be reached */
+    printf("%d\n", r);
+    pthread_join(th, NULL);
+    return 2;
+}


### PR DESCRIPTION
Previously, I was relying on the syscall-return-stop out of execve() to detect that an exec had happened. This had a number of drawbacks:
* Can't be sure which thread executed (although race conditions here are not common)
* Need to read orig_eax on syscall-return-stop to know which syscall we are returning from, although in normal circumstances we should know (it's the one we entered). Also, that value might apparently be set wrong...
* Needed to work around i386/x86_64 transitions, as Linux could report a thread going out of "syscall 59", number for execve in x86_64, although the new program is running in i386 mode

We now react to PTRACE_EVENT_EXEC and do the work there. We then set the flag PROCFLAG_EXECD, so that we know the next syscall-in/out-stop is in fact a return from execve, no matter what Linux reports (and whether or not the thread had entered a syscall before).

Fixes #110