### PR TITLE
Running experiment from very different systems

### DIFF
--- a/.travis/install.sh
+++ b/.travis/install.sh
@@ -4,6 +4,12 @@ run_lines(){
     while read line; do echo "$line"; sh -c "$line" || exit $?; done
 }
 
+if [ -z "${XDG_CACHE_HOME-}" ]; then
+    mkdir -p ~/.cache/reprozip
+else
+    mkdir -p "$XDG_CACHE_HOME/reprozip"
+fi
+
 case "$TEST_MODE"
 in
     run_program|coverage_c)

--- a/reprounzip-docker/reprounzip/unpackers/docker.py
+++ b/reprounzip-docker/reprounzip/unpackers/docker.py
@@ -325,7 +325,7 @@ def docker_run(args):
     for run_number in selected_runs:
         run = runs[run_number]
         cmd = 'cd %s && ' % shell_escape(run['workingdir'])
-        cmd += '/usr/bin/env -i '
+        cmd += '/bin/busybox env -i '
         environ = x11.fix_env(run['environ'])
         cmd += ' '.join('%s=%s' % (k, shell_escape(v))
                         for k, v in iteritems(environ))

--- a/reprounzip-docker/reprounzip/unpackers/docker.py
+++ b/reprounzip-docker/reprounzip/unpackers/docker.py
@@ -217,7 +217,7 @@ def docker_setup_create(args):
                 lfp.write(p.path)
                 lfp.write(b'\0')
         fp.write('    cd / && '
-                 '(tar zpxf /reprozip_experiment.rpz '
+                 '(tar zpxf /reprozip_experiment.rpz -U --recursive-unlink '
                  '--numeric-owner --strip=1 --null -T /rpz-files.list || '
                  '/bin/echo "TAR reports errors, this might or might not '
                  'prevent the execution to run")\n')

--- a/reprounzip-vagrant/reprounzip/unpackers/vagrant/__init__.py
+++ b/reprounzip-vagrant/reprounzip/unpackers/vagrant/__init__.py
@@ -308,6 +308,9 @@ def vagrant_setup_create(args):
             fp.write(r'''
 cp /vagrant/busybox /experimentroot/busybox
 chmod +x /experimentroot/busybox
+mkdir -p /experimentroot/bin
+[ -e /experimentroot/bin/sh ] || \
+    ln -s /busybox /experimentroot/bin/sh
 ''')
 
     # Copies pack

--- a/reprounzip-vagrant/reprounzip/unpackers/vagrant/__init__.py
+++ b/reprounzip-vagrant/reprounzip/unpackers/vagrant/__init__.py
@@ -33,7 +33,7 @@ from reprounzip.unpackers.common import COMPAT_OK, COMPAT_MAYBE, \
 from reprounzip.unpackers.common.x11 import X11Handler
 from reprounzip.unpackers.vagrant.run_command import IgnoreMissingKey, \
     run_interactive
-from reprounzip.utils import unicode_, iteritems, check_output
+from reprounzip.utils import unicode_, iteritems, check_output, download_file
 
 
 def rb_escape(s):
@@ -299,21 +299,16 @@ def vagrant_setup_create(args):
                      '--numeric-owner --strip=1 '
                      '--null -T /vagrant/rpz-files.list || /bin/true\n')
 
-        # Copies /bin/sh + dependencies
+        # Copies busybox
         if use_chroot:
-            url = busybox_url(runs[0]['architecture'])
+            arch = runs[0]['architecture']
+            download_file(busybox_url(arch),
+                          target / 'busybox',
+                          'busybox-%s' % arch)
             fp.write(r'''
-mkdir -p /experimentroot/bin
-mkdir -p /experimentroot/usr/bin
-if [ ! -e /experimentroot/bin/sh -o ! -e /experimentroot/usr/bin/env ]; then
-    wget --quiet -O /experimentroot/bin/busybox {url}
-    chmod +x /experimentroot/bin/busybox
-fi
-[ -e /experimentroot/bin/sh ] || \
-    ln -s /bin/busybox /experimentroot/bin/sh
-[ -e /experimentroot/usr/bin/env ] || \
-    ln -s /bin/busybox /experimentroot/usr/bin/env
-'''.format(url=url))
+cp /vagrant/busybox /experimentroot/busybox
+chmod +x /experimentroot/busybox
+''')
 
     # Copies pack
     logging.info("Copying pack file...")
@@ -382,7 +377,10 @@ def vagrant_run(args):
     for run_number in selected_runs:
         run = runs[run_number]
         cmd = 'cd %s && ' % shell_escape(run['workingdir'])
-        cmd += '/usr/bin/env -i '
+        if use_chroot:
+            cmd += '/busybox env -i '
+        else:
+            cmd += '/usr/bin/env -i '
         environ = x11.fix_env(run['environ'])
         cmd += ' '.join('%s=%s' % (k, shell_escape(v))
                         for k, v in iteritems(environ))

--- a/reprounzip/reprounzip/unpackers/common/__init__.py
+++ b/reprounzip/reprounzip/unpackers/common/__init__.py
@@ -13,8 +13,8 @@ from __future__ import unicode_literals
 from reprounzip.unpackers.common.misc import UsageError, \
     COMPAT_OK, COMPAT_NO, COMPAT_MAYBE, \
     composite_action, target_must_exist, unique_names, \
-    make_unique_name, shell_escape, load_config, busybox_url, join_root, \
-    FileUploader, FileDownloader, get_runs, interruptible_call
+    make_unique_name, shell_escape, load_config, busybox_url, sudo_url, \
+    join_root, FileUploader, FileDownloader, get_runs, interruptible_call
 from reprounzip.unpackers.common.packages import THIS_DISTRIBUTION, \
     PKG_NOT_INSTALLED, CantFindInstaller, select_installer
 
@@ -24,5 +24,6 @@ __all__ = ['THIS_DISTRIBUTION', 'PKG_NOT_INSTALLED', 'select_installer',
            'UsageError', 'CantFindInstaller',
            'composite_action', 'target_must_exist', 'unique_names',
            'make_unique_name', 'shell_escape', 'load_config', 'busybox_url',
+           'sudo_url',
            'join_root', 'FileUploader', 'FileDownloader', 'get_runs',
            'interruptible_call']

--- a/reprounzip/reprounzip/unpackers/common/misc.py
+++ b/reprounzip/reprounzip/unpackers/common/misc.py
@@ -129,6 +129,13 @@ def busybox_url(arch):
     return 'http://www.busybox.net/downloads/binaries/latest/busybox-%s' % arch
 
 
+def sudo_url(arch):
+    """Gets the correct URL for the rpzsudo binary given the architecture.
+    """
+    return ('https://github.com/remram44/static-sudo'
+            '/releases/download/current/rpzsudo-%s' % arch)
+
+
 def join_root(root, path):
     """Prepends `root` to the absolute path `path`.
     """


### PR DESCRIPTION
* [X] When the filesystem hierarchy is very different, when can end up unpacking files or symlinks over directories. There we might want to remove the whole directory, of course leaving the system very broken for everything besides our experiment. Happens on Fedora: `/lib` is a symlink to `/usr/lib`, unpacking over Debian removes Debian's whole `/lib` directory!
* [X] Put busybox in a place where it can't easily get obliterated; `/bin` might get replaced by a symlink, if that happens we'd lose `/bin/busybox`. Hide it somewhere in `/`.
* [x] `sudo` is used by reprounzip-docker and can break very easily. It's not even statically linked!