### PR TITLE
Use PTRACE_EVENT_FORK, ... instead of syscall out

### DIFF
--- a/reprozip/native/syscalls.c
+++ b/reprozip/native/syscalls.c
@@ -964,7 +964,7 @@ int syscall_handle(struct Process *process)
             log_debug(process->tid,
                       "ignoring, EXEC'D is set -- just post-exec syscall-"
                       "return stop");
-        process->flags = 0;
+        process->flags &= ~PROCFLAG_EXECD;
         if(process->execve_info != NULL)
         {
             free_execve_info(process->execve_info);

--- a/reprozip/native/syscalls.c
+++ b/reprozip/native/syscalls.c
@@ -441,88 +441,111 @@ static int syscall_execve_out(const char *name, struct Process *process,
  * fork(), clone(), ...
  */
 
-#define SYSCALL_FORK_FORK   1
-#define SYSCALL_FORK_VFORK  2
-#define SYSCALL_FORK_CLONE  3
+static int syscall_fork_in(const char *name, struct Process *process,
+                           unsigned int udata)
+{
+    process->flags |= PROCFLAG_FORKING;
+    return 0;
+}
 
-static int syscall_forking(const char *name, struct Process *process,
-                           unsigned int syscall)
+static int syscall_fork_out(const char *name, struct Process *process,
+                            unsigned int udata)
+{
+    process->flags &= ~PROCFLAG_FORKING;
+    return 0;
+}
+
+int syscall_fork_event(struct Process *process, unsigned int event)
 {
 #ifndef CLONE_THREAD
 #define CLONE_THREAD 0x00010000
 #endif
-    if(process->retvalue.i > 0)
+
+    int is_thread = 0;
+    struct Process *new_process;
+    unsigned long new_tid;
+
+    ptrace(PTRACE_GETEVENTMSG, process->tid, NULL, &new_tid);
+
+    if(process->flags & PROCFLAG_FORKING == 0)
     {
-        int is_thread = 0;
-        pid_t new_tid = process->retvalue.i;
-        struct Process *new_process;
-        if(syscall == SYSCALL_FORK_CLONE)
-            is_thread = process->params[0].u & CLONE_THREAD;
-        if(verbosity >= 2)
-            log_info(new_tid, "process created by %d via %s\n"
-                     "    (thread: %s) (working directory: %s)",
-                     process->tid,
-                     (syscall == SYSCALL_FORK_FORK)?"fork()":
-                     (syscall == SYSCALL_FORK_VFORK)?"vfork()":
-                     "clone()",
-                     is_thread?"yes":"no",
-                     process->threadgroup->wd);
-
-        /* At this point, the process might have been seen by waitpid in
-         * trace() or not. */
-        new_process = trace_find_process(new_tid);
-        if(new_process != NULL)
-        {
-            /* Process has been seen before and options were set */
-            if(new_process->status != PROCSTAT_UNKNOWN)
-            {
-                /* LCOV_EXCL_START : internal error */
-                log_critical(new_tid,
-                             "just created process that is already running "
-                             "(status=%d)", new_process->status);
-                return -1;
-                /* LCOV_EXCL_END */
-            }
-            new_process->status = PROCSTAT_ATTACHED;
-            ptrace(PTRACE_SYSCALL, new_process->tid, NULL, NULL);
-            if(verbosity >= 2)
-            {
-                unsigned int nproc, unknown;
-                trace_count_processes(&nproc, &unknown);
-                log_info(0, "%d processes (inc. %d unattached)",
-                         nproc, unknown);
-            }
-        }
-        else
-        {
-            /* Process hasn't been seen before (syscall returned first) */
-            new_process = trace_get_empty_process();
-            new_process->status = PROCSTAT_ALLOCATED;
-            new_process->flags = 0;
-            /* New process gets a SIGSTOP, but we resume on attach */
-            new_process->tid = new_tid;
-            new_process->in_syscall = 0;
-        }
-        if(is_thread)
-        {
-            new_process->threadgroup = process->threadgroup;
-            process->threadgroup->refs++;
-            if(verbosity >= 3)
-                log_debug(process->threadgroup->tgid, "threadgroup refs=%d",
-                          process->threadgroup->refs);
-        }
-        else
-            new_process->threadgroup = trace_new_threadgroup(
-                    new_process->tid,
-                    strdup(process->threadgroup->wd));
-
-        /* Parent will also get a SIGTRAP with PTRACE_EVENT_FORK */
-
-        if(db_add_process(&new_process->identifier,
-                          process->identifier,
-                          process->threadgroup->wd) != 0)
-            return -1;
+        /* LCOV_EXCL_START : internal error */
+        log_critical(process->tid,
+                     "process created new process %d but we didn't see syscall "
+                     "entry", new_tid);
+        return -1;
+        /* LCOV_EXCL_END */
     }
+    else if(event == PTRACE_EVENT_CLONE)
+        is_thread = process->params[0].u & CLONE_THREAD;
+    process->flags &= ~PROCFLAG_FORKING;
+
+    if(verbosity >= 2)
+        log_info(new_tid, "process created by %d via %s\n"
+                 "    (thread: %s) (working directory: %s)",
+                 process->tid,
+                 (event == PTRACE_EVENT_FORK)?"fork()":
+                 (event == PTRACE_EVENT_VFORK)?"vfork()":
+                 "clone()",
+                 is_thread?"yes":"no",
+                 process->threadgroup->wd);
+
+    /* At this point, the process might have been seen by waitpid in trace() or
+     * not */
+    new_process = trace_find_process(new_tid);
+    if(new_process != NULL)
+    {
+        /* Process has been seen before and options were set */
+        if(new_process->status != PROCSTAT_UNKNOWN)
+        {
+            /* LCOV_EXCL_START: : internal error */
+            log_critical(new_tid,
+                         "just created process that is already running "
+                         "(status=%d)", new_process->status);
+            return -1;
+            /* LCOV_EXCL_END */
+        }
+        new_process->status = PROCSTAT_ATTACHED;
+        ptrace(PTRACE_SYSCALL, new_process->tid, NULL, NULL);
+        if(verbosity >= 2)
+        {
+            unsigned int nproc, unknown;
+            trace_count_processes(&nproc, &unknown);
+            log_info(0, "%d processes (inc. %d unattached)",
+                     nproc, unknown);
+        }
+    }
+    else
+    {
+        /* Process hasn't been seen before (event happened first) */
+        new_process = trace_get_empty_process();
+        new_process->status = PROCSTAT_ALLOCATED;
+        new_process->flags = 0;
+        /* New process gets a SIGSTOP, but we resume on attach */
+        new_process->tid = new_tid;
+        new_process->in_syscall = 0;
+    }
+
+    if(is_thread)
+    {
+        new_process->threadgroup = process->threadgroup;
+        process->threadgroup->refs++;
+        if(verbosity >= 3)
+            log_debug(process->threadgroup->tgid, "threadgroup refs=%d",
+                      process->threadgroup->refs);
+    }
+    else
+        new_process->threadgroup = trace_new_threadgroup(
+                new_process->tid,
+                strdup(process->threadgroup->wd));
+
+    /* Parent will also get a SIGTRAP with PTRACE_EVENT_FORK */
+
+    if(db_add_process(&new_process->identifier,
+                      process->identifier,
+                      process->threadgroup->wd) != 0)
+        return -1;
+
     return 0;
 }
 
@@ -737,9 +760,9 @@ void syscall_build_table(void)
 
             { 11, "execve", syscall_execve_in, syscall_execve_out, 11},
 
-            {  2, "fork", NULL, syscall_forking, SYSCALL_FORK_FORK},
-            {190, "vfork", NULL, syscall_forking, SYSCALL_FORK_VFORK},
-            {120, "clone", NULL, syscall_forking, SYSCALL_FORK_CLONE},
+            {  2, "fork", syscall_fork_in, syscall_fork_out, 0},
+            {190, "vfork", syscall_fork_in, syscall_fork_out, 0},
+            {120, "clone", syscall_fork_in, syscall_fork_out, 0},
 
             {102, "socketcall", NULL, syscall_socketcall, 0},
 
@@ -807,9 +830,9 @@ void syscall_build_table(void)
 
             { 59, "execve", syscall_execve_in, syscall_execve_out, 59},
 
-            { 57, "fork", NULL, syscall_forking, SYSCALL_FORK_FORK},
-            { 58, "vfork", NULL, syscall_forking, SYSCALL_FORK_VFORK},
-            { 56, "clone", NULL, syscall_forking, SYSCALL_FORK_CLONE},
+            { 57, "fork", syscall_fork_in, syscall_fork_out, 0},
+            { 58, "vfork", syscall_fork_in, syscall_fork_out, 0},
+            { 56, "clone", syscall_fork_in, syscall_fork_out, 0},
 
             { 43, "accept", NULL, syscall_accept, 0},
             {288, "accept4", NULL, syscall_accept, 0},
@@ -876,9 +899,9 @@ void syscall_build_table(void)
             {520, "execve", syscall_execve_in, syscall_execve_out,
                      __X32_SYSCALL_BIT + 520},
 
-            { 57, "fork", NULL, syscall_forking, SYSCALL_FORK_FORK},
-            { 58, "vfork", NULL, syscall_forking, SYSCALL_FORK_VFORK},
-            { 56, "clone", NULL, syscall_forking, SYSCALL_FORK_CLONE},
+            { 57, "fork", syscall_fork_in, syscall_fork_out, 0},
+            { 58, "vfork", syscall_fork_in, syscall_fork_out, 0},
+            { 56, "clone", syscall_fork_in, syscall_fork_out, 0},
 
             { 43, "accept", NULL, syscall_accept, 0},
             {288, "accept4", NULL, syscall_accept, 0},

--- a/reprozip/native/syscalls.h
+++ b/reprozip/native/syscalls.h
@@ -8,5 +8,6 @@ void syscall_build_table(void);
 int syscall_handle(struct Process *process);
 
 int syscall_execve_event(struct Process *process);
+int syscall_fork_event(struct Process *process, unsigned int event);
 
 #endif

--- a/reprozip/native/tracer.c
+++ b/reprozip/native/tracer.c
@@ -526,6 +526,13 @@ static int trace(pid_t first_proc, int *first_exit_code)
                     if(syscall_execve_event(process) != 0)
                         return -1;
                 }
+                else if( (event == PTRACE_EVENT_FORK)
+                      || (event == PTRACE_EVENT_VFORK)
+                      || (event == PTRACE_EVENT_CLONE))
+                {
+                    if(syscall_fork_event(process, event) != 0)
+                        return -1;
+                }
                 ptrace(PTRACE_SYSCALL, tid, NULL, NULL);
             }
             else if(signum == SIGTRAP)

--- a/reprozip/native/tracer.h
+++ b/reprozip/native/tracer.h
@@ -61,6 +61,8 @@ struct Process {
                                  * or x32 */
 
 #define PROCFLAG_EXECD      1   /* Process is coming out of execve */
+#define PROCFLAG_FORKING    2   /* Process is spawning another with
+                                 * fork/vfork/clone */
 
 /* FIXME : This is only exposed because of execve() workaround */
 extern struct Process **processes;

--- a/tests/functional.py
+++ b/tests/functional.py
@@ -438,6 +438,17 @@ def functional_tests(raise_warnings, interactive, run_vagrant, run_docker):
                for l in stderr)
 
     # ########################################
+    # 'vfork' program: testrun
+    #
+
+    # Build
+    build('vfork', ['vfork.c'])
+    # Trace
+    stderr = check_output(rpz + ['testrun', './vfork'], 'err')
+    stderr = stderr.split(b'\n')
+    assert not any(b'program exited with non-zero code' in l for l in stderr)
+
+    # ########################################
     # Copies back coverage report
     #
 

--- a/tests/vfork.c
+++ b/tests/vfork.c
@@ -1,0 +1,35 @@
+/* vfork.c
+ *
+ * This just calls vfork() then execve().
+ *
+ * usage: ./vfork
+ */
+
+#include <sys/types.h>
+#include <sys/wait.h>
+#include <unistd.h>
+
+
+int main(void)
+{
+    pid_t res = vfork();
+    if(res == 0)
+    {
+        char *args[] = {"echo", "hello", NULL};
+        execv("/bin/echo", args);
+    }
+    else if(res > 0)
+    {
+        int status;
+        waitpid(res, &status, 0);
+        if(WIFEXITED(status))
+            return 0;
+        else
+            return 1;
+    }
+    else
+    {
+        perror("vfork");
+        return 2;
+    }
+}


### PR DESCRIPTION
Similar to #114 but for forking instead of exec.

Fixes #121: vfork() is the only one that doesn't work right now (but happens in real-life in my compiler).

Previously, I was only using the syscall-return-stop out of fork(), vfork() or clone() to detect that a successful process creation had happened. This was a problem because syscall return can happen either before or after the process is created. Thus I waited for both to happen before resuming the new process; problem is that vfork() won't let the parent return until the child has exited or called exec; thus we deadlock on vfork().