### PR TITLE
Rename & symlink syscalls

### DIFF
--- a/reprounzip/reprounzip/common.py
+++ b/reprounzip/reprounzip/common.py
@@ -38,6 +38,7 @@ FILE_READ = 0x01
 FILE_WRITE = 0x02
 FILE_WDIR = 0x04
 FILE_STAT = 0x08
+FILE_LINK = 0x10
 
 
 class File(CommonEqualityMixin):

--- a/reprozip/native/database.h
+++ b/reprozip/native/database.h
@@ -3,8 +3,9 @@
 
 #define FILE_READ   0x01
 #define FILE_WRITE  0x02
-#define FILE_WDIR   0x04
-#define FILE_STAT   0x08
+#define FILE_WDIR   0x04  /* File is used as a process's working dir */
+#define FILE_STAT   0x08  /* File is stat()d (only metadata is read) */
+#define FILE_LINK   0x10  /* The link itself is accessed, no dereference */
 
 int db_init(const char *filename);
 int db_close(int rollback);

--- a/reprozip/native/syscalls.c
+++ b/reprozip/native/syscalls.c
@@ -203,14 +203,14 @@ static int syscall_fileopening(const char *name, struct Process *process,
  */
 
 static int syscall_filestat(const char *name, struct Process *process,
-                        unsigned int udata)
+                            unsigned int no_deref)
 {
     if(process->retvalue.i >= 0)
     {
         char *pathname = abs_path_arg(process, 0);
         if(db_add_file_open(process->identifier,
                             pathname,
-                            FILE_STAT,
+                            FILE_STAT | (no_deref?FILE_LINK:0),
                             path_is_dir(pathname)) != 0)
             return -1;
         free(pathname);
@@ -747,11 +747,11 @@ void syscall_build_table(void)
             { 33, "access", NULL, syscall_fileopening, SYSCALL_OPENING_ACCESS},
 
             {106, "stat", NULL, syscall_filestat, 0},
-            {107, "lstat", NULL, syscall_filestat, 0},
+            {107, "lstat", NULL, syscall_filestat, 1},
             {195, "stat64", NULL, syscall_filestat, 0},
             { 18, "oldstat", NULL, syscall_filestat, 0},
-            {196, "lstat64", NULL, syscall_filestat, 0},
-            { 84, "oldlstat", NULL, syscall_filestat, 0},
+            {196, "lstat64", NULL, syscall_filestat, 1},
+            { 84, "oldlstat", NULL, syscall_filestat, 1},
 
             { 85, "readlink", NULL, syscall_readlink, 0},
 
@@ -821,7 +821,7 @@ void syscall_build_table(void)
             { 21, "access", NULL, syscall_fileopening, SYSCALL_OPENING_ACCESS},
 
             {  4, "stat", NULL, syscall_filestat, 0},
-            {  6, "lstat", NULL, syscall_filestat, 0},
+            {  6, "lstat", NULL, syscall_filestat, 1},
 
             { 89, "readlink", NULL, syscall_readlink, 0},
 
@@ -889,7 +889,7 @@ void syscall_build_table(void)
             { 21, "access", NULL, syscall_fileopening, SYSCALL_OPENING_ACCESS},
 
             {  4, "stat", NULL, syscall_filestat, 0},
-            {  6, "lstat", NULL, syscall_filestat, 0},
+            {  6, "lstat", NULL, syscall_filestat, 1},
 
             { 89, "readlink", NULL, syscall_readlink, 0},
 

--- a/reprozip/reprozip/common.py
+++ b/reprozip/reprozip/common.py
@@ -38,6 +38,7 @@ FILE_READ = 0x01
 FILE_WRITE = 0x02
 FILE_WDIR = 0x04
 FILE_STAT = 0x08
+FILE_LINK = 0x10
 
 
 class File(CommonEqualityMixin):

--- a/reprozip/reprozip/tracer/trace.py
+++ b/reprozip/reprozip/tracer/trace.py
@@ -22,7 +22,7 @@ import sqlite3
 from reprozip import __version__ as reprozip_version
 from reprozip import _pytracer
 from reprozip.common import File, InputOutputFile, load_config, save_config, \
-    FILE_READ, FILE_WRITE, FILE_WDIR
+    FILE_READ, FILE_WRITE, FILE_WDIR, FILE_LINK
 from reprozip.orderedset import OrderedSet
 from reprozip.tracer.linux_pkgs import magic_dirs, system_dirs, \
     identify_packages
@@ -140,13 +140,14 @@ def get_files(conn):
             access_files.append(set())
 
         # Adds symbolic links as read files
-        for filename in find_all_links(r_name, False):
+        for filename in find_all_links(r_name.parent if r_mode & FILE_LINK else r_name, False):
             if filename not in files:
                 f = TracedFile(filename)
                 f.read()
                 files[f.path] = f
-        # Adds final target
-        r_name = r_name.resolve()
+        # Go to final target
+        if not r_mode & FILE_LINK:
+            r_name = r_name.resolve()
         if r_name not in files:
             f = TracedFile(r_name)
             files[f.path] = f

--- a/reprozip/reprozip/tracer/trace.py
+++ b/reprozip/reprozip/tracer/trace.py
@@ -140,7 +140,8 @@ def get_files(conn):
             access_files.append(set())
 
         # Adds symbolic links as read files
-        for filename in find_all_links(r_name.parent if r_mode & FILE_LINK else r_name, False):
+        for filename in find_all_links(r_name.parent if r_mode & FILE_LINK
+                                       else r_name, False):
             if filename not in files:
                 f = TracedFile(filename)
                 f.read()

--- a/tests/rename.c
+++ b/tests/rename.c
@@ -1,0 +1,39 @@
+/* rename.c
+ *
+ * This is a very simple program that creates a file, renames it, and opens the
+ * renamed files. It tests the handler for rename(2) & co: the renamed file
+ * shouldn't be packed, but it would be if the handler didn't behave correctly.
+ *
+ * usage: ./rename
+ */
+
+#include <stdio.h>
+
+
+int main(int argc, char **argv)
+{
+    if(mkdir("dir1", 0755) == -1)
+        return 1;
+    if(mkdir("dir2", 0755) == -1)
+        return 1;
+
+    /* rename */
+    {
+        FILE *orig = fopen("dir1/file", "w");
+        if(orig == NULL)
+            return 1;
+        fclose(orig);
+        if(rename("dir1/file", "dir2/file") == -1)
+            return 1;
+    }
+
+    /* broken symlink */
+    if(symlink("dirN/something", "dir2/brokensymlink") == -1)
+        return 1;
+
+    /* working symlink */
+    if(symlink("dir1", "dir2/symlink") == -1)
+        return 1;
+
+    return 0;
+}


### PR DESCRIPTION
Handles rename(), symlink(), link(), and the *at variants (with AT_FDCWD only; cf c233d3e1).

Also adds the FILE_LINK flag, which also means lstat() doesn't mark the link target as read anymore.

Fixes #126