### PR TITLE
'reprounzip info' can take a long time

### DIFF
--- a/reprounzip-docker/reprounzip/unpackers/docker.py
+++ b/reprounzip-docker/reprounzip/unpackers/docker.py
@@ -211,8 +211,7 @@ def docker_setup_create(args):
                                             for pkg in missing_packages)
         for f in chain(other_files, missing_files):
             path = PosixPath('/')
-            # [1:] to skip 'DATA/' prefix
-            for c in f.path.components[1:]:
+            for c in rpz_pack.remove_data_prefix(f.path).components:
                 path = path / c
                 if path in paths:
                     continue

--- a/reprounzip-docker/reprounzip/unpackers/docker.py
+++ b/reprounzip-docker/reprounzip/unpackers/docker.py
@@ -13,6 +13,7 @@ See http://www.docker.io/
 from __future__ import division, print_function, unicode_literals
 
 import argparse
+import copy
 from itertools import chain
 import json
 import logging
@@ -134,7 +135,7 @@ def docker_setup_create(args):
 
     # Unpacks configuration file
     tar = tarfile.open(str(pack), 'r:*')
-    member = tar.getmember('METADATA/config.yml')
+    member = copy.copy(tar.getmember('METADATA/config.yml'))
     member.name = 'config.yml'
     tar.extract(member, str(target))
     tar.close()

--- a/reprounzip-vagrant/reprounzip/unpackers/vagrant/__init__.py
+++ b/reprounzip-vagrant/reprounzip/unpackers/vagrant/__init__.py
@@ -269,8 +269,7 @@ def vagrant_setup_create(args):
             # tar
             for f in other_files:
                 path = PosixPath('/')
-                # [1:] to skip 'DATA/' prefix
-                for c in f.path.components[1:]:
+                for c in rpz_pack.remove_data_prefix(f.path).components:
                     path = path / c
                     if path in paths:
                         continue

--- a/reprounzip-vagrant/reprounzip/unpackers/vagrant/__init__.py
+++ b/reprounzip-vagrant/reprounzip/unpackers/vagrant/__init__.py
@@ -14,6 +14,7 @@ See http://www.vagrantup.com/
 from __future__ import division, print_function, unicode_literals
 
 import argparse
+import copy
 from distutils.version import LooseVersion
 import logging
 import os
@@ -188,7 +189,7 @@ def vagrant_setup_create(args):
 
     # Unpacks configuration file
     tar = tarfile.open(str(pack), 'r:*')
-    member = tar.getmember('METADATA/config.yml')
+    member = copy.copy(tar.getmember('METADATA/config.yml'))
     member.name = 'config.yml'
     tar.extract(member, str(target))
     tar.close()

--- a/reprounzip/reprounzip/common.py
+++ b/reprounzip/reprounzip/common.py
@@ -21,17 +21,21 @@ package that reprozip and reprounzip would both depend on.
 from __future__ import division, print_function, unicode_literals
 
 import atexit
+import contextlib
+import copy
 from datetime import datetime
 from distutils.version import LooseVersion
 import logging
 import logging.handlers
 import os
 from rpaths import PosixPath, Path
+import tarfile
 import usagestats
 import yaml
 
 from .utils import iteritems, itervalues, unicode_, stderr, UniqueNames, \
-    escape, CommonEqualityMixin, hsize, optional_return_type
+    escape, CommonEqualityMixin, hsize, optional_return_type, join_root, \
+    copyfile
 
 
 FILE_READ = 0x01
@@ -76,6 +80,164 @@ class Package(CommonEqualityMixin):
     __str__ = __unicode__
 
 
+# Pack format history:
+# 1: used by reprozip 0.2 through 0.7. Single tar.gz file, metadata under
+#   METADATA/, data under DATA/
+# 2: pack is usually not compressed, metadata under METADATA/, data in another
+#   DATA.tar.gz (files inside it still have the DATA/ prefix for ease-of-use
+#   in unpackers)
+#
+# Pack metadata history:
+# 0.2: used by reprozip 0.2
+# 0.2.1:
+#     config: comments directories as such in config
+#     trace database: adds executed_files.workingdir, adds processes.exitcode
+#     data: packs dynamic linkers
+# 0.3:
+#     config: don't list missing (unpacked) files in config
+#     trace database: adds opened_files.is_directory
+# 0.3.1: no change
+# 0.3.2: no change
+# 0.4:
+#     config: adds input_files, output_files, lists parent directories
+# 0.4.1: no change
+# 0.5: no change
+# 0.6: no change
+# 0.7: moves input_files and output_files from run to global scope
+
+
+class RPZPack(object):
+    """Encapsulates operations on the RPZ pack format.
+    """
+    def __init__(self, pack):
+        self.pack = Path(pack)
+
+        self.tar = tarfile.open(str(self.pack), 'r:*')
+        f = self.tar.extractfile('METADATA/version')
+        version = f.read()
+        f.close()
+        if version.startswith(b'REPROZIP VERSION '):
+            try:
+                version = int(version[17:].rstrip())
+            except ValueError:
+                version = None
+            if version in (1, 2):
+                self.version = version
+                self.data_prefix = PosixPath(b'DATA')
+            else:
+                raise ValueError(
+                    "Unknown format version %r (maybe you should upgrade "
+                    "reprounzip? I only know versions 1 and 2" % version)
+        else:
+            raise ValueError("File doesn't appear to be a RPZ pack")
+
+        if self.version == 1:
+            self.data = self.tar
+        elif version == 2:
+            self.data = tarfile.open(
+                fileobj=self.tar.extractfile('DATA.tar.gz'),
+                mode='r:*')
+        else:
+            assert False
+
+    def open_config(self):
+        """Gets the configuration file.
+        """
+        return self.tar.extractfile('METADATA/config.yml')
+
+    def extract_config(self, target):
+        """Extracts the config to the specified path.
+
+        It is up to the caller to remove that file once done.
+        """
+        member = copy.copy(self.tar.getmember('METADATA/config.yml'))
+        member.name = str(target.components[-1])
+        self.tar.extract(member,
+                         path=str(Path.cwd() / target.parent))
+        assert target.is_file()
+
+    @contextlib.contextmanager
+    def with_config(self):
+        """Context manager that extracts the config to  a temporary file.
+        """
+        fd, tmp = Path.tempfile(prefix='reprounzip_')
+        os.close(fd)
+        self.extract_config(tmp)
+        yield tmp
+        tmp.remove()
+
+    def extract_trace(self, target):
+        """Extracts the trace database to the specified path.
+
+        It is up to the caller to remove that file once done.
+        """
+        target = Path(target)
+        if self.version == 1:
+            member = self.tar.getmember('METADATA/trace.sqlite3')
+        elif self.version == 2:
+            try:
+                member = self.tar.getmember('METADATA/trace.sqlite3.gz')
+            except KeyError:
+                member = self.tar.getmember('METADATA/trace.sqlite3')
+        else:
+            assert False
+        member = copy.copy(member)
+        member.name = str(target.components[-1])
+        self.tar.extract(member,
+                         path=str(Path.cwd() / target.parent))
+        assert target.is_file()
+
+    @contextlib.contextmanager
+    def with_trace(self):
+        """Context manager that extracts the trace database to a temporary file.
+        """
+        fd, tmp = Path.tempfile(prefix='reprounzip_')
+        os.close(fd)
+        self.extract_trace(tmp)
+        yield tmp
+        tmp.remove()
+
+    def list_data(self):
+        """Returns tarfile.TarInfo objects for all the data paths.
+        """
+        return [copy.copy(m)
+                for m in self.data.getmembers()
+                if m.name.startswith('DATA/')]
+
+    def get_data(self, path):
+        """Returns a tarfile.TarInfo object for the data path.
+
+        Raises KeyError if no such path exists.
+        """
+        path = PosixPath(path)
+        path = join_root(PosixPath(b'DATA'), path)
+        return copy.copy(self.data.getmember(path))
+
+    def extract_data(self, root, members):
+        """Extracts the given members from the data tarball.
+
+        The members must come from get_data().
+        """
+        self.data.extractall(str(root), members)
+
+    def copy_data_tar(self, target):
+        """Copies the file in which the data lies to the specified destination.
+        """
+        if self.version == 1:
+            self.pack.copyfile(target)
+        elif self.version == 2:
+            with target.open('wb') as fp:
+                data = self.tar.extractfile('DATA.tar.gz')
+                copyfile(data, fp)
+                data.close()
+
+    def close(self):
+        if self.data is not self.tar:
+            self.data.close()
+        self.tar.close()
+        self.data = self.tar = None
+
+
 class InvalidConfig(ValueError):
     """Configuration file is invalid.
     """
@@ -95,25 +257,6 @@ def read_packages(packages, File=File, Package=Package):
         pkg['files'] = read_files(pkg['files'], File)
         new_pkgs.append(Package(**pkg))
     return new_pkgs
-
-
-# Pack format history:
-# 0.2: used by reprozip 0.2
-# 0.2.1:
-#     config: comments directories as such in config
-#     trace database: adds executed_files.workingdir, adds processes.exitcode
-#     data: packs dynamic linkers
-# 0.3:
-#     config: don't list missing (unpacked) files in config
-#     trace database: adds opened_files.is_directory
-# 0.3.1: no change
-# 0.3.2: no change
-# 0.4:
-#     config: adds input_files, output_files, lists parent directories
-# 0.4.1: no change
-# 0.5: no change
-# 0.6: no change
-# 0.7: moves input_files and output_files from run to global scope
 
 
 Config = optional_return_type(['runs', 'packages', 'other_files'],

--- a/reprounzip/reprounzip/common.py
+++ b/reprounzip/reprounzip/common.py
@@ -140,6 +140,11 @@ class RPZPack(object):
         else:
             assert False
 
+    def remove_data_prefix(self, path):
+        if not isinstance(path, PosixPath):
+            path = PosixPath(path)
+        return path.__class__(*path.components[1:])
+
     def open_config(self):
         """Gets the configuration file.
         """

--- a/reprounzip/reprounzip/pack_info.py
+++ b/reprounzip/reprounzip/pack_info.py
@@ -19,9 +19,8 @@ import pickle
 import platform
 from rpaths import Path
 import sys
-import tarfile
 
-from reprounzip.common import load_config as load_config_file
+from reprounzip.common import RPZPack, load_config as load_config_file
 from reprounzip.main import unpackers
 from reprounzip.unpackers.common import load_config, COMPAT_OK, COMPAT_MAYBE, \
     COMPAT_NO, shell_escape
@@ -43,10 +42,8 @@ def print_info(args):
     pack_dirs = 0
     pack_symlinks = 0
     pack_others = 0
-    tar = tarfile.open(str(pack), 'r:*')
-    for m in tar.getmembers():
-        if not m.name.startswith('DATA/'):
-            continue
+    rpz_pack = RPZPack(pack)
+    for m in rpz_pack.list_data():
         pack_total_size += m.size
         pack_total_paths += 1
         if m.isfile():
@@ -57,7 +54,7 @@ def print_info(args):
             pack_symlinks += 1
         else:
             pack_others += 1
-    tar.close()
+    rpz_pack.close()
 
     meta_total_paths = 0
     meta_packed_packages_files = 0

--- a/reprounzip/reprounzip/unpackers/common/__init__.py
+++ b/reprounzip/reprounzip/unpackers/common/__init__.py
@@ -10,11 +10,12 @@ pack files.
 
 from __future__ import division, print_function, unicode_literals
 
+from reprounzip.utils import join_root
 from reprounzip.unpackers.common.misc import UsageError, \
     COMPAT_OK, COMPAT_NO, COMPAT_MAYBE, \
     composite_action, target_must_exist, unique_names, \
     make_unique_name, shell_escape, load_config, busybox_url, sudo_url, \
-    join_root, FileUploader, FileDownloader, get_runs, interruptible_call
+    FileUploader, FileDownloader, get_runs, interruptible_call
 from reprounzip.unpackers.common.packages import THIS_DISTRIBUTION, \
     PKG_NOT_INSTALLED, CantFindInstaller, select_installer
 

--- a/reprounzip/reprounzip/unpackers/common/misc.py
+++ b/reprounzip/reprounzip/unpackers/common/misc.py
@@ -236,8 +236,7 @@ class FileUploader(object):
                                                  input_path)))
         except KeyError:
             return None
-        name = temp.components[-1]
-        member.name = str(name)
+        member.name = str(temp.components[-1])
         tar.extract(member, str(temp.parent))
         tar.close()
         return temp

--- a/reprounzip/reprounzip/unpackers/common/misc.py
+++ b/reprounzip/reprounzip/unpackers/common/misc.py
@@ -19,7 +19,7 @@ import sys
 import tarfile
 
 import reprounzip.common
-from reprounzip.utils import irange, iteritems, stdout_bytes
+from reprounzip.utils import irange, iteritems, stdout_bytes, join_root
 
 
 COMPAT_OK = 0
@@ -135,14 +135,6 @@ def sudo_url(arch):
     """
     return ('https://github.com/remram44/static-sudo'
             '/releases/download/current/rpzsudo-%s' % arch)
-
-
-def join_root(root, path):
-    """Prepends `root` to the absolute path `path`.
-    """
-    p_root, p_loc = path.split_root()
-    assert p_root == b'/'
-    return root / p_loc
 
 
 class FileUploader(object):

--- a/reprounzip/reprounzip/unpackers/common/misc.py
+++ b/reprounzip/reprounzip/unpackers/common/misc.py
@@ -7,6 +7,7 @@
 
 from __future__ import division, print_function, unicode_literals
 
+import copy
 import functools
 import logging
 import os
@@ -236,6 +237,7 @@ class FileUploader(object):
                                                  input_path)))
         except KeyError:
             return None
+        member = copy.copy(member)
         member.name = str(temp.components[-1])
         tar.extract(member, str(temp.parent))
         tar.close()

--- a/reprounzip/reprounzip/unpackers/common/misc.py
+++ b/reprounzip/reprounzip/unpackers/common/misc.py
@@ -19,7 +19,8 @@ import sys
 import tarfile
 
 import reprounzip.common
-from reprounzip.utils import irange, iteritems, stdout_bytes, join_root
+from reprounzip.utils import irange, iteritems, stdout_bytes, join_root, \
+    copyfile
 
 
 COMPAT_OK = 0
@@ -303,13 +304,7 @@ class FileDownloader(object):
         self.download(remote_path, temp)
         # Output to stdout
         with temp.open('rb') as fp:
-            chunk = fp.read(1024)
-            if chunk:
-                stdout_bytes.write(chunk)
-            while len(chunk) == 1024:
-                chunk = fp.read(1024)
-                if chunk:
-                    stdout_bytes.write(chunk)
+            copyfile(fp, stdout_bytes)
         temp.remove()
 
     def download(self, remote_path, local_path):

--- a/reprounzip/reprounzip/unpackers/default.py
+++ b/reprounzip/reprounzip/unpackers/default.py
@@ -36,7 +36,8 @@ from reprounzip.unpackers.common import THIS_DISTRIBUTION, PKG_NOT_INSTALLED, \
     FileUploader, FileDownloader, get_runs, interruptible_call
 from reprounzip.unpackers.common.x11 import X11Handler, LocalForwarder
 from reprounzip.utils import unicode_, irange, iteritems, \
-    stdout_bytes, stderr, make_dir_writable, rmtree_fixed, download_file
+    stdout_bytes, stderr, make_dir_writable, rmtree_fixed, copyfile, \
+    download_file
 
 
 def installpkgs(args):
@@ -723,13 +724,7 @@ class LocalDownloader(FileDownloader):
                              remote_path)
             sys.exit(1)
         with remote_path.open('rb') as fp:
-            chunk = fp.read(1024)
-            if chunk:
-                stdout_bytes.write(chunk)
-            while len(chunk) == 1024:
-                chunk = fp.read(1024)
-                if chunk:
-                    stdout_bytes.write(chunk)
+            copyfile(fp, stdout_bytes)
 
     def download(self, remote_path, local_path):
         remote_path = join_root(self.root, remote_path)

--- a/reprounzip/reprounzip/unpackers/default.py
+++ b/reprounzip/reprounzip/unpackers/default.py
@@ -17,6 +17,7 @@ This file contains the default plugins that come with reprounzip:
 from __future__ import division, print_function, unicode_literals
 
 import argparse
+import copy
 import logging
 import os
 import pickle
@@ -131,7 +132,7 @@ def directory_create(args):
 
     # Unpacks configuration file
     tar = tarfile.open(str(pack), 'r:*')
-    member = tar.getmember('METADATA/config.yml')
+    member = copy.copy(tar.getmember('METADATA/config.yml'))
     member.name = 'config.yml'
     tar.extract(member, str(target))
 
@@ -164,7 +165,9 @@ def directory_create(args):
     if any('..' in m.name or m.name.startswith('/') for m in tar.getmembers()):
         logging.critical("Tar archive contains invalid pathnames")
         sys.exit(1)
-    members = [m for m in tar.getmembers() if m.name.startswith('DATA/')]
+    members = [copy.copy(m)
+               for m in tar.getmembers()
+               if m.name.startswith('DATA/')]
     for m in members:
         m.name = m.name[5:]
     # Makes symlink targets relative
@@ -406,7 +409,7 @@ def chroot_create(args):
 
     # Unpacks configuration file
     tar = tarfile.open(str(pack), 'r:*')
-    member = tar.getmember('METADATA/config.yml')
+    member = copy.copy(tar.getmember('METADATA/config.yml'))
     member.name = 'config.yml'
     tar.extract(member, str(target))
 
@@ -454,7 +457,9 @@ def chroot_create(args):
     if any('..' in m.name or m.name.startswith('/') for m in tar.getmembers()):
         logging.critical("Tar archive contains invalid pathnames")
         sys.exit(1)
-    members = [m for m in tar.getmembers() if m.name.startswith('DATA/')]
+    members = [copy.copy(m)
+               for m in tar.getmembers()
+               if m.name.startswith('DATA/')]
     for m in members:
         m.name = m.name[5:]
     if not restore_owner:
@@ -665,6 +670,7 @@ class LocalUploader(FileUploader):
     def extract_original_input(self, input_name, input_path, temp):
         tar = tarfile.open(str(self.target / 'inputs.tar.gz'), 'r:*')
         member = tar.getmember(str(join_root(PosixPath(''), input_path)))
+        member = copy.copy(member)
         member.name = str(temp.components[-1])
         tar.extract(member, str(temp.parent))
         tar.close()

--- a/reprounzip/reprounzip/unpackers/default.py
+++ b/reprounzip/reprounzip/unpackers/default.py
@@ -162,7 +162,8 @@ def directory_create(args):
                       "them.\nUse 'reprounzip installpkgs -h' for help")
 
     # Unpacks files
-    if any('..' in m.name or m.name.startswith('/') for m in tar.getmembers()):
+    if any('..' in PosixPath(m.name).components or m.name.startswith('/')
+           for m in tar.getmembers()):
         logging.critical("Tar archive contains invalid pathnames")
         sys.exit(1)
     members = [copy.copy(m)
@@ -454,7 +455,8 @@ def chroot_create(args):
             record_usage(chroot_mising_files=True)
 
     # Unpacks files
-    if any('..' in m.name or m.name.startswith('/') for m in tar.getmembers()):
+    if any('..' in PosixPath(m.name).components or m.name.startswith('/')
+           for m in tar.getmembers()):
         logging.critical("Tar archive contains invalid pathnames")
         sys.exit(1)
     members = [copy.copy(m)

--- a/reprounzip/reprounzip/unpackers/default.py
+++ b/reprounzip/reprounzip/unpackers/default.py
@@ -163,13 +163,9 @@ def directory_create(args):
 
     # Unpacks files
     members = rpz_pack.list_data()
-    if rpz_pack.data_prefix != PosixPath(''):
-        prefixlen = len(str(rpz_pack.data_prefix)) + 1  # +1 for '/'
-    else:
-        prefixlen = 0
     for m in members:
         # Remove 'DATA/' prefix
-        m.name = m.name[prefixlen:]
+        m.name = str(rpz_pack.remove_data_prefix(m.name))
         # Makes symlink targets relative
         if m.issym():
             linkname = PosixPath(m.linkname)
@@ -451,13 +447,9 @@ def chroot_create(args):
 
     # Unpacks files
     members = rpz_pack.list_data()
-    if rpz_pack.data_prefix != PosixPath(''):
-        prefixlen = len(str(rpz_pack.data_prefix)) + 1  # +1 for '/'
-    else:
-        prefixlen = 0
     for m in members:
         # Remove 'DATA/' prefix
-        m.name = m.name[prefixlen:]
+        m.name = str(rpz_pack.remove_data_prefix(m.name))
     if not restore_owner:
         uid = os.getuid()
         gid = os.getgid()

--- a/reprounzip/reprounzip/unpackers/default.py
+++ b/reprounzip/reprounzip/unpackers/default.py
@@ -665,7 +665,7 @@ class LocalUploader(FileUploader):
     def extract_original_input(self, input_name, input_path, temp):
         tar = tarfile.open(str(self.target / 'inputs.tar.gz'), 'r:*')
         member = tar.getmember(str(join_root(PosixPath(''), input_path)))
-        member.name = str(temp.name)
+        member.name = str(temp.components[-1])
         tar.extract(member, str(temp.parent))
         tar.close()
         return temp

--- a/reprounzip/reprounzip/unpackers/default.py
+++ b/reprounzip/reprounzip/unpackers/default.py
@@ -28,7 +28,8 @@ import subprocess
 import sys
 import tarfile
 
-from reprounzip.common import load_config as load_config_file, record_usage
+from reprounzip.common import RPZPack, load_config as load_config_file, \
+    record_usage
 from reprounzip import signals
 from reprounzip.unpackers.common import THIS_DISTRIBUTION, PKG_NOT_INSTALLED, \
     COMPAT_OK, COMPAT_NO, UsageError, CantFindInstaller, target_must_exist, \
@@ -132,10 +133,8 @@ def directory_create(args):
     signals.pre_setup(target=target, pack=pack)
 
     # Unpacks configuration file
-    tar = tarfile.open(str(pack), 'r:*')
-    member = copy.copy(tar.getmember('METADATA/config.yml'))
-    member.name = 'config.yml'
-    tar.extract(member, str(target))
+    rpz_pack = RPZPack(pack)
+    rpz_pack.extract_config(target / 'config.yml')
 
     # Loads config
     config = load_config_file(target / 'config.yml', True)
@@ -163,25 +162,22 @@ def directory_create(args):
                       "them.\nUse 'reprounzip installpkgs -h' for help")
 
     # Unpacks files
-    if any('..' in PosixPath(m.name).components or m.name.startswith('/')
-           for m in tar.getmembers()):
-        logging.critical("Tar archive contains invalid pathnames")
-        sys.exit(1)
-    members = [copy.copy(m)
-               for m in tar.getmembers()
-               if m.name.startswith('DATA/')]
+    members = rpz_pack.list_data()
+    if rpz_pack.data_prefix != PosixPath(''):
+        prefixlen = len(str(rpz_pack.data_prefix)) + 1  # +1 for '/'
+    else:
+        prefixlen = 0
     for m in members:
-        m.name = m.name[5:]
-    # Makes symlink targets relative
-    for m in members:
-        if not m.issym():
-            continue
-        linkname = PosixPath(m.linkname)
-        if linkname.is_absolute:
-            m.linkname = join_root(root, PosixPath(m.linkname)).path
+        # Remove 'DATA/' prefix
+        m.name = m.name[prefixlen:]
+        # Makes symlink targets relative
+        if m.issym():
+            linkname = PosixPath(m.linkname)
+            if linkname.is_absolute:
+                m.linkname = join_root(root, PosixPath(m.linkname)).path
     logging.info("Extracting files...")
-    tar.extractall(str(root), members)
-    tar.close()
+    rpz_pack.extract_data(root, members)
+    rpz_pack.close()
 
     # Gets library paths
     lib_dirs = []
@@ -410,10 +406,8 @@ def chroot_create(args):
     restore_owner = should_restore_owner(args.restore_owner)
 
     # Unpacks configuration file
-    tar = tarfile.open(str(pack), 'r:*')
-    member = copy.copy(tar.getmember('METADATA/config.yml'))
-    member.name = 'config.yml'
-    tar.extract(member, str(target))
+    rpz_pack = RPZPack(pack)
+    rpz_pack.extract_config(target / 'config.yml')
 
     # Loads config
     config = load_config_file(target / 'config.yml', True)
@@ -456,15 +450,14 @@ def chroot_create(args):
             record_usage(chroot_mising_files=True)
 
     # Unpacks files
-    if any('..' in PosixPath(m.name).components or m.name.startswith('/')
-           for m in tar.getmembers()):
-        logging.critical("Tar archive contains invalid pathnames")
-        sys.exit(1)
-    members = [copy.copy(m)
-               for m in tar.getmembers()
-               if m.name.startswith('DATA/')]
+    members = rpz_pack.list_data()
+    if rpz_pack.data_prefix != PosixPath(''):
+        prefixlen = len(str(rpz_pack.data_prefix)) + 1  # +1 for '/'
+    else:
+        prefixlen = 0
     for m in members:
-        m.name = m.name[5:]
+        # Remove 'DATA/' prefix
+        m.name = m.name[prefixlen:]
     if not restore_owner:
         uid = os.getuid()
         gid = os.getgid()
@@ -472,8 +465,8 @@ def chroot_create(args):
             m.uid = uid
             m.gid = gid
     logging.info("Extracting files...")
-    tar.extractall(str(root), members)
-    tar.close()
+    rpz_pack.extract_data(root, members)
+    rpz_pack.close()
 
     # Sets up /bin/sh and /usr/bin/env, downloading busybox if necessary
     sh_path = join_root(root, Path('/bin/sh'))

--- a/reprounzip/reprounzip/utils.py
+++ b/reprounzip/reprounzip/utils.py
@@ -290,6 +290,14 @@ def find_all_links(filename, include_target=False):
     return files
 
 
+def join_root(root, path):
+    """Prepends `root` to the absolute path `path`.
+    """
+    p_root, p_loc = path.split_root()
+    assert p_root == b'/'
+    return root / p_loc
+
+
 @contextlib.contextmanager
 def make_dir_writable(directory):
     """Context-manager that sets write permission on a directory.

--- a/reprounzip/reprounzip/utils.py
+++ b/reprounzip/reprounzip/utils.py
@@ -385,7 +385,7 @@ def download_file(url, dest, cachename=None):
     The cache lives in ``~/.cache/reprozip/``.
     """
     if cachename is None:
-        cachename = dest.name
+        cachename = dest.components[-1]
 
     request = Request(url)
 

--- a/reprounzip/reprounzip/utils.py
+++ b/reprounzip/reprounzip/utils.py
@@ -384,6 +384,17 @@ def check_output(*popenargs, **kwargs):
     return out
 
 
+def copyfile(source, destination, CHUNK_SIZE=4096):
+    """Copies from one file object to another.
+    """
+    while True:
+        chunk = source.read(CHUNK_SIZE)
+        if chunk:
+            destination.write(chunk)
+        if len(chunk) != CHUNK_SIZE:
+            break
+
+
 def download_file(url, dest, cachename=None):
     """Downloads a file using a local cache.
 
@@ -429,13 +440,8 @@ def download_file(url, dest, cachename=None):
 
     logging.info("Download %s: downloading %s", cachename, url)
     try:
-        CHUNK_SIZE = 4096
         with cache.open('wb') as f:
-            while True:
-                chunk = response.read(CHUNK_SIZE)
-                if not chunk:
-                    break
-                f.write(chunk)
+            copyfile(response, f)
         response.close()
     except Exception as e:  # pragma: no cover
         try:

--- a/reprozip/reprozip/common.py
+++ b/reprozip/reprozip/common.py
@@ -21,17 +21,21 @@ package that reprozip and reprounzip would both depend on.
 from __future__ import division, print_function, unicode_literals
 
 import atexit
+import contextlib
+import copy
 from datetime import datetime
 from distutils.version import LooseVersion
 import logging
 import logging.handlers
 import os
 from rpaths import PosixPath, Path
+import tarfile
 import usagestats
 import yaml
 
 from .utils import iteritems, itervalues, unicode_, stderr, UniqueNames, \
-    escape, CommonEqualityMixin, hsize, optional_return_type
+    escape, CommonEqualityMixin, hsize, optional_return_type, join_root, \
+    copyfile
 
 
 FILE_READ = 0x01
@@ -76,6 +80,164 @@ class Package(CommonEqualityMixin):
     __str__ = __unicode__
 
 
+# Pack format history:
+# 1: used by reprozip 0.2 through 0.7. Single tar.gz file, metadata under
+#   METADATA/, data under DATA/
+# 2: pack is usually not compressed, metadata under METADATA/, data in another
+#   DATA.tar.gz (files inside it still have the DATA/ prefix for ease-of-use
+#   in unpackers)
+#
+# Pack metadata history:
+# 0.2: used by reprozip 0.2
+# 0.2.1:
+#     config: comments directories as such in config
+#     trace database: adds executed_files.workingdir, adds processes.exitcode
+#     data: packs dynamic linkers
+# 0.3:
+#     config: don't list missing (unpacked) files in config
+#     trace database: adds opened_files.is_directory
+# 0.3.1: no change
+# 0.3.2: no change
+# 0.4:
+#     config: adds input_files, output_files, lists parent directories
+# 0.4.1: no change
+# 0.5: no change
+# 0.6: no change
+# 0.7: moves input_files and output_files from run to global scope
+
+
+class RPZPack(object):
+    """Encapsulates operations on the RPZ pack format.
+    """
+    def __init__(self, pack):
+        self.pack = Path(pack)
+
+        self.tar = tarfile.open(str(self.pack), 'r:*')
+        f = self.tar.extractfile('METADATA/version')
+        version = f.read()
+        f.close()
+        if version.startswith(b'REPROZIP VERSION '):
+            try:
+                version = int(version[17:].rstrip())
+            except ValueError:
+                version = None
+            if version in (1, 2):
+                self.version = version
+                self.data_prefix = PosixPath(b'DATA')
+            else:
+                raise ValueError(
+                    "Unknown format version %r (maybe you should upgrade "
+                    "reprounzip? I only know versions 1 and 2" % version)
+        else:
+            raise ValueError("File doesn't appear to be a RPZ pack")
+
+        if self.version == 1:
+            self.data = self.tar
+        elif version == 2:
+            self.data = tarfile.open(
+                fileobj=self.tar.extractfile('DATA.tar.gz'),
+                mode='r:*')
+        else:
+            assert False
+
+    def open_config(self):
+        """Gets the configuration file.
+        """
+        return self.tar.extractfile('METADATA/config.yml')
+
+    def extract_config(self, target):
+        """Extracts the config to the specified path.
+
+        It is up to the caller to remove that file once done.
+        """
+        member = copy.copy(self.tar.getmember('METADATA/config.yml'))
+        member.name = str(target.components[-1])
+        self.tar.extract(member,
+                         path=str(Path.cwd() / target.parent))
+        assert target.is_file()
+
+    @contextlib.contextmanager
+    def with_config(self):
+        """Context manager that extracts the config to  a temporary file.
+        """
+        fd, tmp = Path.tempfile(prefix='reprounzip_')
+        os.close(fd)
+        self.extract_config(tmp)
+        yield tmp
+        tmp.remove()
+
+    def extract_trace(self, target):
+        """Extracts the trace database to the specified path.
+
+        It is up to the caller to remove that file once done.
+        """
+        target = Path(target)
+        if self.version == 1:
+            member = self.tar.getmember('METADATA/trace.sqlite3')
+        elif self.version == 2:
+            try:
+                member = self.tar.getmember('METADATA/trace.sqlite3.gz')
+            except KeyError:
+                member = self.tar.getmember('METADATA/trace.sqlite3')
+        else:
+            assert False
+        member = copy.copy(member)
+        member.name = str(target.components[-1])
+        self.tar.extract(member,
+                         path=str(Path.cwd() / target.parent))
+        assert target.is_file()
+
+    @contextlib.contextmanager
+    def with_trace(self):
+        """Context manager that extracts the trace database to a temporary file.
+        """
+        fd, tmp = Path.tempfile(prefix='reprounzip_')
+        os.close(fd)
+        self.extract_trace(tmp)
+        yield tmp
+        tmp.remove()
+
+    def list_data(self):
+        """Returns tarfile.TarInfo objects for all the data paths.
+        """
+        return [copy.copy(m)
+                for m in self.data.getmembers()
+                if m.name.startswith('DATA/')]
+
+    def get_data(self, path):
+        """Returns a tarfile.TarInfo object for the data path.
+
+        Raises KeyError if no such path exists.
+        """
+        path = PosixPath(path)
+        path = join_root(PosixPath(b'DATA'), path)
+        return copy.copy(self.data.getmember(path))
+
+    def extract_data(self, root, members):
+        """Extracts the given members from the data tarball.
+
+        The members must come from get_data().
+        """
+        self.data.extractall(str(root), members)
+
+    def copy_data_tar(self, target):
+        """Copies the file in which the data lies to the specified destination.
+        """
+        if self.version == 1:
+            self.pack.copyfile(target)
+        elif self.version == 2:
+            with target.open('wb') as fp:
+                data = self.tar.extractfile('DATA.tar.gz')
+                copyfile(data, fp)
+                data.close()
+
+    def close(self):
+        if self.data is not self.tar:
+            self.data.close()
+        self.tar.close()
+        self.data = self.tar = None
+
+
 class InvalidConfig(ValueError):
     """Configuration file is invalid.
     """
@@ -95,25 +257,6 @@ def read_packages(packages, File=File, Package=Package):
         pkg['files'] = read_files(pkg['files'], File)
         new_pkgs.append(Package(**pkg))
     return new_pkgs
-
-
-# Pack format history:
-# 0.2: used by reprozip 0.2
-# 0.2.1:
-#     config: comments directories as such in config
-#     trace database: adds executed_files.workingdir, adds processes.exitcode
-#     data: packs dynamic linkers
-# 0.3:
-#     config: don't list missing (unpacked) files in config
-#     trace database: adds opened_files.is_directory
-# 0.3.1: no change
-# 0.3.2: no change
-# 0.4:
-#     config: adds input_files, output_files, lists parent directories
-# 0.4.1: no change
-# 0.5: no change
-# 0.6: no change
-# 0.7: moves input_files and output_files from run to global scope
 
 
 Config = optional_return_type(['runs', 'packages', 'other_files'],

--- a/reprozip/reprozip/common.py
+++ b/reprozip/reprozip/common.py
@@ -140,6 +140,11 @@ class RPZPack(object):
         else:
             assert False
 
+    def remove_data_prefix(self, path):
+        if not isinstance(path, PosixPath):
+            path = PosixPath(path)
+        return path.__class__(*path.components[1:])
+
     def open_config(self):
         """Gets the configuration file.
         """

--- a/reprozip/reprozip/utils.py
+++ b/reprozip/reprozip/utils.py
@@ -290,6 +290,14 @@ def find_all_links(filename, include_target=False):
     return files
 
 
+def join_root(root, path):
+    """Prepends `root` to the absolute path `path`.
+    """
+    p_root, p_loc = path.split_root()
+    assert p_root == b'/'
+    return root / p_loc
+
+
 @contextlib.contextmanager
 def make_dir_writable(directory):
     """Context-manager that sets write permission on a directory.

--- a/reprozip/reprozip/utils.py
+++ b/reprozip/reprozip/utils.py
@@ -385,7 +385,7 @@ def download_file(url, dest, cachename=None):
     The cache lives in ``~/.cache/reprozip/``.
     """
     if cachename is None:
-        cachename = dest.name
+        cachename = dest.components[-1]
 
     request = Request(url)
 

--- a/reprozip/reprozip/utils.py
+++ b/reprozip/reprozip/utils.py
@@ -384,6 +384,17 @@ def check_output(*popenargs, **kwargs):
     return out
 
 
+def copyfile(source, destination, CHUNK_SIZE=4096):
+    """Copies from one file object to another.
+    """
+    while True:
+        chunk = source.read(CHUNK_SIZE)
+        if chunk:
+            destination.write(chunk)
+        if len(chunk) != CHUNK_SIZE:
+            break
+
+
 def download_file(url, dest, cachename=None):
     """Downloads a file using a local cache.
 
@@ -429,13 +440,8 @@ def download_file(url, dest, cachename=None):
 
     logging.info("Download %s: downloading %s", cachename, url)
     try:
-        CHUNK_SIZE = 4096
         with cache.open('wb') as f:
-            while True:
-                chunk = response.read(CHUNK_SIZE)
-                if not chunk:
-                    break
-                f.write(chunk)
+            copyfile(response, f)
         response.close()
     except Exception as e:  # pragma: no cover
         try:

--- a/tests/functional.py
+++ b/tests/functional.py
@@ -246,10 +246,10 @@ def functional_tests(raise_warnings, interactive, run_vagrant, run_docker):
     check_call(sudo + rpuz + ['chroot', 'setup', '--bind-magic-dirs',
                               'simple.rpz', 'simplechroot'])
     try:
-        # Run chroot
-        check_simple(sudo + rpuz + ['chroot', 'run', 'simplechroot'], 'err')
         output_in_chroot = join_root(Path('simplechroot/root'),
                                      orig_output_location)
+        # Run chroot
+        check_simple(sudo + rpuz + ['chroot', 'run', 'simplechroot'], 'err')
         with output_in_chroot.open(encoding='utf-8') as fp:
             assert fp.read().strip() == '42'
         # Get output file
@@ -263,10 +263,14 @@ def functional_tests(raise_warnings, interactive, run_vagrant, run_docker):
         check_call(sudo + rpuz + ['chroot', 'upload', 'simplechroot'])
         # Run again
         check_simple(sudo + rpuz + ['chroot', 'run', 'simplechroot'], 'err', 2)
-        output_in_chroot = join_root(Path('simplechroot/root'),
-                                     orig_output_location)
         with output_in_chroot.open(encoding='utf-8') as fp:
             assert fp.read().strip() == '36'
+        # Reset input file
+        check_call(sudo + rpuz + ['chroot', 'upload', 'simplechroot', ':arg1'])
+        # Run again
+        check_simple(sudo + rpuz + ['chroot', 'run', 'simplechroot'], 'err')
+        with output_in_chroot.open(encoding='utf-8') as fp:
+            assert fp.read().strip() == '42'
         # Delete with wrong command (should fail)
         p = subprocess.Popen(rpuz + ['directory', 'destroy', 'simplechroot'],
                              stderr=subprocess.PIPE)
@@ -314,6 +318,20 @@ def functional_tests(raise_warnings, interactive, run_vagrant, run_docker):
                                'arg2:voutput2.txt'])
             with Path('voutput2.txt').open(encoding='utf-8') as fp:
                 assert fp.read().strip() == '36'
+            # Reset input file
+            check_call(rpuz + ['vagrant', 'upload',
+                               (tests / 'vagrant/simplevagrantchroot').path,
+                               ':arg1'])
+            # Run again
+            check_simple(rpuz + ['vagrant', 'run', '--no-stdin',
+                                 (tests / 'vagrant/simplevagrantchroot').path],
+                         'out')
+            # Get output file
+            check_call(rpuz + ['vagrant', 'download',
+                               (tests / 'vagrant/simplevagrantchroot').path,
+                               'arg2:voutput1.txt'])
+            with Path('voutput1.txt').open(encoding='utf-8') as fp:
+                assert fp.read().strip() == '42'
             # Destroy
             check_call(rpuz + ['vagrant', 'destroy',
                                (tests / 'vagrant/simplevagrantchroot').path])
@@ -355,6 +373,20 @@ def functional_tests(raise_warnings, interactive, run_vagrant, run_docker):
                                'arg2:woutput2.txt'])
             with Path('woutput2.txt').open(encoding='utf-8') as fp:
                 assert fp.read().strip() == '36'
+            # Reset input file
+            check_call(rpuz + ['vagrant', 'upload',
+                               (tests / 'vagrant/simplevagrant').path,
+                               ':arg1'])
+            # Run again
+            check_simple(rpuz + ['vagrant', 'run', '--no-stdin',
+                                 (tests / 'vagrant/simplevagrant').path],
+                         'out')
+            # Get output file
+            check_call(rpuz + ['vagrant', 'download',
+                               (tests / 'vagrant/simplevagrant').path,
+                               'arg2:voutput1.txt'])
+            with Path('voutput1.txt').open(encoding='utf-8') as fp:
+                assert fp.read().strip() == '42'
             # Destroy
             check_call(rpuz + ['vagrant', 'destroy',
                                (tests / 'vagrant/simplevagrant').path])
@@ -389,6 +421,16 @@ def functional_tests(raise_warnings, interactive, run_vagrant, run_docker):
                                'arg2:doutput2.txt'])
             with Path('doutput2.txt').open(encoding='utf-8') as fp:
                 assert fp.read().strip() == '36'
+            # Reset input file
+            check_call(rpuz + ['docker', 'upload', 'simpledocker',
+                               ':arg1'])
+            # Run again
+            check_simple(rpuz + ['docker', 'run', 'simpledocker'], 'out')
+            # Get output file
+            check_call(rpuz + ['docker', 'download', 'simpledocker',
+                               'arg2:doutput1.txt'])
+            with Path('doutput1.txt').open(encoding='utf-8') as fp:
+                assert fp.read().strip() == '42'
             # Destroy
             check_call(rpuz + ['docker', 'destroy', 'simpledocker'])
         elif interactive:


### PR DESCRIPTION
We need to decompress the whole tar.gz to read the configuration file (this is a tar.gz limitation). This can take a long time, even if we just need the small configuration file.