### PR TITLE
Add selectable levels of detail to the 'graph' command

### DIFF
--- a/docs/graph.rst
+++ b/docs/graph.rst
@@ -1,0 +1,81 @@
+..  _graph:
+
+reprounzip graph
+****************
+
+`reprounzip` comes with the *graph* unpackers. Instead of turning a .rpz pack into an executable directory, it reads the metadata and creates a graph that shows the processes of the original experiment and the files they access.
+
+..  note:: If you are using a Python version older than 2.7.3, this feature will not be available due to `Python bug 13676 <http://bugs.python.org/issue13676>`__ related to sqlite3.
+
+The basic usage is either::
+
+    reprounzip graph graphfile.dot mypackfile.rpz
+
+or, if you just ran `reprozip` and haven't created a pack yet::
+
+    reprounzip graph [-d tracedirectory] graphfile.dot
+
+The default output is a `Graphviz DOT file <http://www.graphviz.org/content/dot-language>`__ that you can turn into an image using for example::
+
+    dot -Tpng graphfile.dot -o graph.png
+
+It is also possible to output a JSON file with ``--json``, which is easier to consume in other programs.
+
+Options
+=======
+
+Because most experiments involve a huge number of file accesses, the graph command offers a lot of options to control what will be shown.
+
+Note that all of the following options can be passed multiple times.
+
+Filtering
++++++++++
+
+Files can be filtered out using a regular expression [#re]_ with ``--regex-filter``; for example:
+
+* ``--regex-filter /~[^/]*$``` will filter out files whose name begin with a tilde
+* ``--regex-filter ^/usr/share`` will filter out /usr/share recursively
+* ``--regex-filter \.bin$`` will filter files with a .bin extension
+
+Mapping
++++++++
+
+You can remap filenames using regular expressions [#re]_ with ``--regex-replace``. This can be useful either:
+
+* to simplify the graph by making filenames shorter, or
+* to aggregate multiple files by mapping them to the same name, or
+* to fix programs for which the wrong access was logged or which is using some kind of cache, like Python's .pyc files
+
+Example:
+
+* ``--regex-replace .pyc$ \.py`` will replace accesses to bytecode cache files (.pyc) to the original source (.py)
+* ``--regex-replace ^/dev(/.*)?$ /dev`` will aggregate all device files as a single path `/dev`
+* ``--regex-replace ^/home/vagrant/experiment/data/(.*)\.bin data:\1`` simplifies the paths to some data files
+
+``--aggregate`` is a shortcut allowing to map all files that begin with a prefix to that prefix, for instance ``--aggregate /usr/local`` will collapse all files under ``/usr/local`` as if there was a single path ``/usr/local`` that was used instead of them.
+
+Levels of detail
+++++++++++++++++
+
+You can also control how each category of items should be detailed in the output.
+
+For distribution packages:
+
+* ``--packages file`` will show all the files belonging to each package, grouped under that package's name
+* ``--packages package`` will show the package as a single item, not detailing the individual files it contains
+* ``--packages drop`` will hide the packages entirely, removing all of their files from the output
+* ``--packages ignore`` will ignore the packages, treating their files as if they had not been detected as being part of a package
+
+Note that regex filters and replacements are applied before this, so files that are remapped to a package file will show under that package name (for example, .pyc to .py).
+
+For processes:
+
+* ``--processes thread`` will show every process and thread
+* ``--processes process`` will show every process but hide threads
+* ``--processes run`` will show only one item for a whole run, as if it only used a single process
+
+For the files that are not part of a package (or if ``--packages ignore`` is in use):
+
+* ``--otherfiles all`` will show every file (unless filtered by ``--regex-filter``)
+* ``--otherfiles io`` will only show the input and output files, as designated by the configuration
+* ``--otherfiles no`` will not show these files at all

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -22,6 +22,7 @@ Contents
     install
     packing
     unpacking
+    graph
     faq
     glossary
     developerguide

--- a/docs/unpacking.rst
+++ b/docs/unpacking.rst
@@ -101,14 +101,7 @@ This command is particularly useful if you want to replace an input file with yo
 Creating a Provenance Graph
 +++++++++++++++++++++++++++
 
-ReproZip also allows users to generate a *provenance graph* related to the experiment execution. This graph shows the relationships between files, library dependencies, and binaries during the execution. To generate such a graph, the ``reprounzip graph`` command should be used::
-
-    $ reprounzip graph graph-file.dot package.rpz
-    $ dot -Tpng graph-file.dot -o image.png
-
-where `graph-file.dot` corresponds to the graph, outputted in the `DOT <http://en.wikipedia.org/wiki/DOT_(graph_description_language)>`__ language. You can use `Graphviz <http://www.graphviz.org/>`__ to load and visualize the graph.
-
-..  note:: If you are using a Python version older than 2.7.3, this feature will not be available due to `Python bug 13676 <http://bugs.python.org/issue13676>`__ related to sqlite3.
+While not actually geared toward re-execution, reprounzip bundles a 'graph' unpackers, that read a package's metadata to generate a *provenance graph* showing the processes of the original experiment and the files they access. See :ref:`graph` for details.
 
 ..  _unpack-unpackers:
 

--- a/reprounzip/reprounzip/unpackers/graph.py
+++ b/reprounzip/reprounzip/unpackers/graph.py
@@ -210,8 +210,14 @@ class Package(object):
             return '"%s"' % escape(unicode_(f))
 
     def json(self, level_pkgs):
+        if level_pkgs == LVL_PKG_PACKAGE:
+            files = []
+        elif level_pkgs == LVL_PKG_FILE:
+            files = list(self.files)
+        else:
+            assert False
         return {'name': self.name, 'version': self.version or None,
-                'files': []}
+                'files': files}
 
 
 def parse_levels(level_pkgs, level_processes, level_other_files):

--- a/reprounzip/reprounzip/unpackers/graph.py
+++ b/reprounzip/reprounzip/unpackers/graph.py
@@ -480,6 +480,11 @@ def graph(args):
     Reads in the trace sqlite3 database and writes out a graph in GraphViz DOT
     format.
     """
+    def call_generate(args, directory):
+        generate(Path(args.target[0]), directory, args.all_forks,
+                 args.packages, args.processes, args.otherfiles,
+                 args.regex_filter)
+
     if args.pack is not None:
         tmp = Path.tempdir(prefix='reprounzip_')
         try:
@@ -495,17 +500,11 @@ def graph(args):
                 tar.extract('METADATA/trace.sqlite3', path=str(tmp))
             except KeyError as e:
                 logging.critical("Error extracting from pack: %s", e.args[0])
-            generate(Path(args.target[0]),
-                     tmp / 'METADATA',
-                     args.all_forks,
-                     args.packages, args.processes, args.otherfiles,
-                     args.regex_filter)
+            call_generate(args, tmp / 'METADATA')
         finally:
             tmp.rmtree()
     else:
-        generate(Path(args.target[0]), Path(args.dir), args.all_forks,
-                 args.packages, args.processes, args.otherfiles,
-                 args.regex_filter)
+        call_generate(args, Path(args.dir))
 
 
 def disabled_bug13676(args):

--- a/reprounzip/reprounzip/unpackers/graph.py
+++ b/reprounzip/reprounzip/unpackers/graph.py
@@ -616,14 +616,21 @@ def graph_json(target, runs, packages, other_files, package_map, edges,
 
     json_other_files.sort()
 
-    with target.open('w', encoding='utf-8', newline='\n') as fp:
-        json.dump({'packages': sorted(itervalues(json_packages),
+    if PY3:
+        fp = target.open('w', encoding='utf-8', newline='\n')
+    else:
+        fp = target.open('wb')
+    try:
+        json.dump({'packages': sorted(json_packages,
                                       key=lambda p: p['name']),
                    'other_files': json_other_files,
                    'runs': json_runs},
                   fp,
+                  ensure_ascii=False,
                   indent=2,
                   sort_keys=True)
+    finally:
+        fp.close()
 
 
 def graph(args):

--- a/reprounzip/reprounzip/unpackers/graph.py
+++ b/reprounzip/reprounzip/unpackers/graph.py
@@ -335,6 +335,14 @@ def read_events(database, all_forks):
     return runs, files, edges
 
 
+def format_argv(argv):
+    joined = ' '.join(argv)
+    if len(joined) < 50:
+        return joined
+    else:
+        return "%s ..." % argv[0]
+
+
 def generate(target, directory, all_forks=False, level_pkgs='file',
              level_processes='thread', level_other_files='all',
              regex_filters=None, regex_replaces=None, aggregates=None):
@@ -497,7 +505,7 @@ def generate(target, directory, all_forks=False, level_pkgs='file',
                 fp.write('    %s -> %s [style=bold, label="%s"];\n' % (
                          endp_file,
                          endp_prog,
-                         escape(' '.join(argv))))
+                         escape(format_argv(argv))))
             elif mode & FILE_WRITE:
                 fp.write('    %s -> %s [color="#000088"];\n' % (
                          endp_prog, endp_file))

--- a/reprounzip/reprounzip/unpackers/graph.py
+++ b/reprounzip/reprounzip/unpackers/graph.py
@@ -148,7 +148,11 @@ class Process(object):
             return 'prog%d' % prog.id
 
     def json(self, process_map):
-        name = "%s (%d)" % (self.binary or "-", self.pid)
+        name = "%d" % self.pid
+        long_name = "%s (%d)" % (PosixPath(self.binary).components[-1]
+                                 if self.binary else "-",
+                                 self.pid)
+        description = "%s\n%d" % (self.binary, self.pid)
         if self.parent is not None:
             if self.created == C_FORK:
                 reason = "fork"
@@ -161,7 +165,8 @@ class Process(object):
             parent = [process_map[self.parent], reason]
         else:
             parent = None
-        return {'name': name, 'parent': parent, 'reads': [], 'writes': []}
+        return {'name': name, 'parent': parent, 'reads': [], 'writes': [],
+                'long_name': long_name, 'description': description}
 
 
 class Package(object):

--- a/reprounzip/reprounzip/unpackers/graph.py
+++ b/reprounzip/reprounzip/unpackers/graph.py
@@ -370,8 +370,8 @@ def generate(target, directory, all_forks=False, level_pkgs='file',
             return None
         if not (replace or aggregates):
             return path
-        for f in replace:
-            pathuni_ = f(pathuni)
+        for fi in replace:
+            pathuni_ = fi(pathuni)
             if pathuni_ != pathuni:
                 logging.debug("SUB %s -> %s", pathuni, pathuni_)
             pathuni = pathuni_
@@ -383,17 +383,17 @@ def generate(target, directory, all_forks=False, level_pkgs='file',
         return PosixPath(pathuni)
 
     files_new = set()
-    for f in files:
-        f = filefilter(f)
-        if f is not None:
-            files_new.add(f)
+    for fi in files:
+        fi = filefilter(fi)
+        if fi is not None:
+            files_new.add(fi)
     files = files_new
 
     edges_new = OrderedSet()
-    for prog, f, mode, argv in edges:
-        f = filefilter(f)
-        if f is not None:
-            edges_new.add((prog, f, mode, argv))
+    for prog, fi, mode, argv in edges:
+        fi = filefilter(fi)
+        if fi is not None:
+            edges_new.add((prog, fi, mode, argv))
     edges = edges_new
 
     # Puts files in packages
@@ -412,17 +412,17 @@ def generate(target, directory, all_forks=False, level_pkgs='file',
                             for pkg in config.packages for f in pkg.files)
         packages = {}
         other_files = []
-        for f in files:
-            pkg = file2package.get(f)
+        for fi in files:
+            pkg = file2package.get(fi)
             if pkg is not None:
                 package = packages.get(pkg.name)
                 if package is None:
                     package = Package(pkg.name, pkg.version)
                     packages[pkg.name] = package
-                package.files.add(f)
-                package_map[f] = package
+                package.files.add(fi)
+                package_map[fi] = package
             else:
-                other_files.append(f)
+                other_files.append(fi)
         packages = list(itervalues(packages))
 
     # Filter other files
@@ -471,19 +471,19 @@ def generate(target, directory, all_forks=False, level_pkgs='file',
 
         # Other files
         logging.info("Writing other files...")
-        for f in sorted(other_files):
-            fp.write('    "%s";\n' % escape(unicode_(f)))
+        for fi in sorted(other_files):
+            fp.write('    "%s";\n' % escape(unicode_(fi)))
 
         fp.write('\n')
 
         # Edges
         logging.info("Connecting edges...")
-        for prog, f, mode, argv in edges:
+        for prog, fi, mode, argv in edges:
             endp_prog = prog.dot_endpoint(level_processes)
-            if f in package_map:
-                endp_file = package_map[f].dot_endpoint(f, level_processes)
+            if fi in package_map:
+                endp_file = package_map[fi].dot_endpoint(fi, level_processes)
             else:
-                endp_file = '"%s"' % escape(unicode_(f))
+                endp_file = '"%s"' % escape(unicode_(fi))
 
             if mode is None:
                 fp.write('    %s -> %s [color=blue, label="%s"];\n' % (

--- a/reprounzip/reprounzip/unpackers/graph.py
+++ b/reprounzip/reprounzip/unpackers/graph.py
@@ -334,17 +334,19 @@ def graph(args):
                 logging.critical("Error extracting from pack: %s", e.args[0])
             generate(Path(args.target[0]),
                      tmp / 'METADATA',
-                     args.all_forks)
+                     args.all_forks,
+                     args.packages, args.processes, args.otherfiles)
         finally:
             tmp.rmtree()
     else:
-        generate(Path(args.target[0]), Path(args.dir), args.all_forks)
+        generate(Path(args.target[0]), Path(args.dir), args.all_forks,
+                 args.packages, args.processes, args.otherfiles)
 
 
 def disabled_bug13676(args):
     stderr.write("Error: your version of Python, %s, is not supported\n"
                  "Versions before 2.7.3 are affected by bug 13676 and will "
-                 "not work be able to\nread the trace "
+                 "not be able to read\nthe trace "
                  "database\n" % sys.version.split(' ', 1)[0])
     sys.exit(1)
 
@@ -364,6 +366,15 @@ def setup(parser, **kwargs):
     parser.add_argument('target', nargs=1, help="Destination DOT file")
     parser.add_argument('-F', '--all-forks', action='store_true',
                         help="Show forked processes before they exec")
+    parser.add_argument('--packages', default='file',
+                        help="Level of detail for packages; 'file', 'package' "
+                        "or 'ignore' (default: 'file')")
+    parser.add_argument('--processes', default='thread',
+                        help="Level of detail for processes; 'thread', "
+                        "'process' or 'run' (default: 'thread')")
+    parser.add_argument('--otherfiles', default='all',
+                        help="Level of detail for non-package files; 'all', "
+                        "'io' or 'no' (default: 'all')")
     parser.add_argument(
         '-d', '--dir', default='.reprozip-trace',
         help="where the database and configuration file are stored (default: "

--- a/reprounzip/reprounzip/unpackers/graph.py
+++ b/reprounzip/reprounzip/unpackers/graph.py
@@ -28,7 +28,7 @@ import tarfile
 
 from reprounzip.common import FILE_READ, FILE_WRITE, FILE_WDIR, load_config
 from reprounzip.orderedset import OrderedSet
-from reprounzip.unpackers.common import COMPAT_OK, COMPAT_NO
+from reprounzip.unpackers.common import COMPAT_OK, COMPAT_NO, UsageError
 from reprounzip.utils import PY3, unicode_, itervalues, stderr, escape, \
     normalize_path
 
@@ -209,7 +209,7 @@ class Package(object):
 
     def json(self, level_pkgs):
         if level_pkgs == LVL_PKG_PACKAGE:
-            files = []
+            raise UsageError("JSON output doesn't support --packages package")
         elif level_pkgs == LVL_PKG_FILE:
             files = sorted(unicode_(f) for f in self.files)
         else:
@@ -612,13 +612,14 @@ def graph_json(target, runs, packages, other_files, package_map, edges,
 
     # Connect edges
     for prog, f, mode, argv in edges:
+        what = unicode_(f)
         if mode is None:
-            prog_map[prog]['reads'].append(unicode_(f))
+            prog_map[prog]['reads'].append(what)
             # TODO: argv?
         elif mode & FILE_WRITE:
-            prog_map[prog]['writes'].append(unicode_(f))
+            prog_map[prog]['writes'].append(what)
         elif mode & FILE_READ:
-            prog_map[prog]['reads'].append(unicode_(f))
+            prog_map[prog]['reads'].append(what)
 
     json_other_files.sort()
 

--- a/reprounzip/reprounzip/unpackers/graph.py
+++ b/reprounzip/reprounzip/unpackers/graph.py
@@ -240,7 +240,7 @@ def read_events(database, all_forks):
     file_cursor = conn.cursor()
     file_rows = file_cursor.execute(
         '''
-        SELECT name, timestamp, mode, process
+        SELECT name, timestamp, mode, process, is_directory
         FROM opened_files
         ORDER BY id
         ''')
@@ -288,9 +288,9 @@ def read_events(database, all_forks):
             run.processes.append(process)
 
         elif event_type == 'open':
-            r_name, r_timestamp, r_mode, r_process = data
+            r_name, r_timestamp, r_mode, r_process, r_directory = data
             r_name = normalize_path(r_name)
-            if r_mode != FILE_WDIR:
+            if not (r_mode & FILE_WDIR or r_directory):
                 process = processes[r_process]
                 files.add(r_name)
                 edges.add((process, r_name, r_mode, None))

--- a/tests/common.py
+++ b/tests/common.py
@@ -1,0 +1,107 @@
+# Copyright (C) 2014-2015 New York University
+# This file is part of ReproZip which is released under the Revised BSD License
+# See file LICENSE for full license details.
+
+from __future__ import print_function, unicode_literals
+
+from rpaths import Path
+import sqlite3
+
+from reprounzip.utils import PY3
+
+
+def make_database(insert, path=None):
+    if path is not None:
+        path = Path(path)
+        if PY3:
+            # On PY3, connect() only accepts unicode
+            conn = sqlite3.connect(str(path))
+        else:
+            conn = sqlite3.connect(path.path)
+    else:
+        conn = sqlite3.connect('')
+    conn.row_factory = sqlite3.Row
+
+    conn.execute(
+            '''
+            CREATE TABLE processes(
+                id INTEGER NOT NULL PRIMARY KEY,
+                run_id INTEGER NOT NULL,
+                parent INTEGER,
+                timestamp INTEGER NOT NULL,
+                is_thread BOOLEAN NOT NULL,
+                exitcode INTEGER
+                );
+            ''')
+    conn.execute(
+            '''
+            CREATE INDEX proc_parent_idx ON processes(parent);
+            ''')
+    conn.execute(
+            '''
+            CREATE TABLE opened_files(
+                id INTEGER NOT NULL PRIMARY KEY,
+                run_id INTEGER NOT NULL,
+                name TEXT NOT NULL,
+                timestamp INTEGER NOT NULL,
+                mode INTEGER NOT NULL,
+                is_directory BOOLEAN NOT NULL,
+                process INTEGER NOT NULL
+                );
+            ''')
+    conn.execute(
+            '''
+            CREATE INDEX open_proc_idx ON opened_files(process);
+            ''')
+    conn.execute(
+            '''
+            CREATE TABLE executed_files(
+                id INTEGER NOT NULL PRIMARY KEY,
+                name TEXT NOT NULL,
+                run_id INTEGER NOT NULL,
+                timestamp INTEGER NOT NULL,
+                process INTEGER NOT NULL,
+                argv TEXT NOT NULL,
+                envp TEXT NOT NULL,
+                workingdir TEXT NOT NULL
+                );
+            ''')
+    conn.execute(
+            '''
+            CREATE INDEX exec_proc_idx ON executed_files(process);
+            ''')
+
+    for timestamp, l in enumerate(insert):
+        if l[0] == 'proc':
+            ident, parent = l[1:]
+            conn.execute(
+                    '''
+                    INSERT INTO processes(id, run_id, parent, timestamp,
+                                          is_thread, exitcode)
+                    VALUES(?, 0, ?, ?, 0, 0);
+                    ''',
+                    (ident, parent, timestamp))
+        elif l[0] == 'open':
+            process, name, is_dir, mode = l[1:]
+            conn.execute(
+                    '''
+                    INSERT INTO opened_files(run_id, name, timestamp, mode,
+                                             is_directory, process)
+                    VALUES(0, ?, ?, ?, ?, ?);
+                    ''',
+                    (name, timestamp, mode, is_dir, process))
+        elif l[0] == 'exec':
+            process, name, wdir, argv = l[1:]
+            conn.execute(
+                    '''
+                    INSERT INTO executed_files(run_id, name, timestamp,
+                                               process, argv, envp,
+                                               workingdir)
+                    VALUES(0, ?, ?, ?, ?, "", ?);
+                    ''',
+                    (name, timestamp, process, argv, wdir))
+        else:
+            assert False
+
+    conn.commit()
+    return conn

--- a/tests/common.py
+++ b/tests/common.py
@@ -73,14 +73,14 @@ def make_database(insert, path=None):
 
     for timestamp, l in enumerate(insert):
         if l[0] == 'proc':
-            ident, parent = l[1:]
+            ident, parent, is_thread = l[1:]
             conn.execute(
                     '''
                     INSERT INTO processes(id, run_id, parent, timestamp,
                                           is_thread, exitcode)
-                    VALUES(?, 0, ?, ?, 0, 0);
+                    VALUES(?, 0, ?, ?, ?, 0);
                     ''',
-                    (ident, parent, timestamp))
+                    (ident, parent, timestamp, is_thread))
         elif l[0] == 'open':
             process, name, is_dir, mode = l[1:]
             conn.execute(

--- a/tests/test_graph.py
+++ b/tests/test_graph.py
@@ -1,0 +1,263 @@
+# Copyright (C) 2014-2015 New York University
+# This file is part of ReproZip which is released under the Revised BSD License
+# See file LICENSE for full license details.
+
+from __future__ import print_function, unicode_literals
+
+import json
+import os
+from rpaths import Path
+import unittest
+
+from reprounzip.common import FILE_READ, FILE_WRITE, FILE_WDIR, FILE_STAT
+from reprounzip.unpackers import graph
+
+from tests.common import make_database
+
+
+class TestGraph(unittest.TestCase):
+    """Generates graphs from a fabricated trace database."""
+    maxDiff = None
+
+    @classmethod
+    def setUpClass(cls):
+        cls._trace = Path.tempdir(prefix='rpz_testdb_')
+        conn = make_database([
+            ('proc', 0, None, False),
+            ('open', 0, "/some/dir", True, FILE_WDIR),
+            ('exec', 0, "/bin/sh", "/some/dir", "sh\0script_1\0"),
+            ('open', 0, "/usr/share/1_one.pyc", False, FILE_READ),
+            ('open', 0, "/some/dir/one", False, FILE_WRITE),
+            ('exec', 0, "/usr/bin/python", "/some/dir", "python\0drive.py\0"),
+            ('open', 0, "/some/dir/drive.py", False, FILE_READ),
+            ('open', 0, "/some/dir/one", False, FILE_READ),
+            ('open', 0, "/etc/2_two.cfg", False, FILE_READ),
+            ('proc', 1, 0, False),
+            ('open', 1, "/some/dir", True, FILE_WDIR),
+            ('exec', 1, "/some/dir/experiment", "/some/dir", "experiment\0"),
+            ('open', 1, "/some/dir/one", False, FILE_STAT),
+            ('open', 1, "/usr/lib/2_one.so", False, FILE_READ),
+            ('open', 1, "/some/dir/two", False, FILE_WRITE),
+            ('exec', 0, "/usr/bin/wc", "/some/dir", "wc\0out.txt\0"),
+            ('open', 0, "/some/dir/two", False, FILE_READ),
+
+            ('proc', 2, None, False),
+            ('open', 2, "/some/dir", True, FILE_WDIR),
+            ('exec', 2, "/bin/sh", "/some/dir", "sh\0script_2\0"),
+            ('proc', 3, 2, True),
+            ('open', 3, "/some/dir", True, FILE_WDIR),
+            ('exec', 3, "/usr/bin/python", "/some/dir", "python\0-\0"),
+            ('open', 3, "/some/dir/one", False, FILE_READ),
+            ('open', 3, "/some/dir/thing", False, FILE_WRITE),
+            ('exec', 2, "/some/dir/report", "/some/dir", "./report\0-v\0"),
+            ('open', 2, "/some/dir/thing", False, FILE_READ),
+            ('open', 2, "/some/dir/result", False, FILE_WRITE),
+        ], cls._trace / 'trace.sqlite3')
+        conn.close()
+        with (cls._trace / 'config.yml').open('w', encoding='utf-8') as fp:
+            fp.write("""\
+version: "0.7"
+runs:
+- architecture: x86_64
+  argv: [./one]
+  binary: /some/dir/one
+  distribution: [debian, '8.0']
+  environ: {USER: remram}
+  exitcode: 0
+  uid: 1000
+  gid: 1000
+  hostname: test
+  workingdir: /user/dir
+
+inputs_outputs:
+
+packages:
+- name: pkg1
+  version: "1.0"
+  size: 10000
+  packfiles: true
+  files:
+  - "/usr/share/1_one.py"
+  - "/usr/share/1_two.py"
+  - "/usr/bin/wc"
+- name: pkg2
+  version: "1.0"
+  size: 10000
+  packfiles: true
+  files:
+  - "/usr/lib/2_one.so"
+  - "/etc/2_two.cfg"
+- name: python
+  version: "2.7"
+  size: 5000000
+  packfiles: true
+  files:
+  - "/usr/bin/python"
+- name: unused
+  version: "0.1"
+  size: 100
+  packfiles: true
+  files:
+  - "/an/unused/file"
+
+other_files:
+- "/bin/sh"
+- "/usr/share/1_one.pyc"
+- "/some/dir/drive.py"
+- "/some/dir/experiment"
+- "/some/dir/report"
+""")
+
+    @classmethod
+    def tearDownClass(cls):
+        cls._trace.rmtree()
+
+    def test_dot(self):
+        fd, target = Path.tempfile(prefix='rpz_testgraph_', suffix='.dot')
+        os.close(fd)
+        try:
+            graph.generate(target, self._trace)
+            with target.open('r') as fp:
+                self.assertEqual("""\
+digraph G {
+    /* programs */
+    node [shape=box fontcolor=white fillcolor=black style=filled];
+    prog0 [label="/bin/sh (0)"];
+    prog1 [label="/usr/bin/python (0)"];
+    prog0 -> prog1 [label="exec"];
+    prog2 [label="/some/dir/experiment (1)"];
+    prog1 -> prog2 [label="fork+exec"];
+    prog3 [label="/usr/bin/wc (0)"];
+    prog1 -> prog3 [label="exec"];
+    prog4 [label="/bin/sh (2)"];
+    prog5 [label="/usr/bin/python (3)"];
+    prog4 -> prog5 [label="fork+exec"];
+    prog6 [label="/some/dir/report (2)"];
+    prog4 -> prog6 [label="exec"];
+
+    node [shape=ellipse fontcolor="#131C39" fillcolor="#C9D2ED"];
+
+    /* system packages */
+    subgraph cluster0 {
+        label="pkg1 1.0";
+        "/usr/bin/wc";
+    }
+    subgraph cluster1 {
+        label="pkg2 1.0";
+        "/etc/2_two.cfg";
+        "/usr/lib/2_one.so";
+    }
+    subgraph cluster2 {
+        label="python 2.7";
+        "/usr/bin/python";
+    }
+
+    /* other files */
+    "/bin/sh";
+    "/some/dir/drive.py";
+    "/some/dir/experiment";
+    "/some/dir/one";
+    "/some/dir/report";
+    "/some/dir/result";
+    "/some/dir/thing";
+    "/some/dir/two";
+    "/usr/share/1_one.pyc";
+
+    "/bin/sh" -> prog0 [style=bold, label="sh script_1"];
+    "/usr/share/1_one.pyc" -> prog0 [color="#8888CC"];
+    prog0 -> "/some/dir/one" [color="#000088"];
+    "/usr/bin/python" -> prog1 [style=bold, label="python drive.py"];
+    "/some/dir/drive.py" -> prog1 [color="#8888CC"];
+    "/some/dir/one" -> prog1 [color="#8888CC"];
+    "/etc/2_two.cfg" -> prog1 [color="#8888CC"];
+    "/some/dir/experiment" -> prog2 [style=bold, label="experiment"];
+    "/usr/lib/2_one.so" -> prog2 [color="#8888CC"];
+    prog2 -> "/some/dir/two" [color="#000088"];
+    "/usr/bin/wc" -> prog3 [style=bold, label="wc out.txt"];
+    "/some/dir/two" -> prog3 [color="#8888CC"];
+    "/bin/sh" -> prog4 [style=bold, label="sh script_2"];
+    "/usr/bin/python" -> prog5 [style=bold, label="python -"];
+    "/some/dir/one" -> prog5 [color="#8888CC"];
+    prog5 -> "/some/dir/thing" [color="#000088"];
+    "/some/dir/report" -> prog6 [style=bold, label="./report -v"];
+    "/some/dir/thing" -> prog6 [color="#8888CC"];
+    prog6 -> "/some/dir/result" [color="#000088"];
+}
+""", fp.read())
+        finally:
+            target.remove()
+
+    def test_json(self):
+        fd, target = Path.tempfile(prefix='rpz_testgraph_', suffix='.json')
+        os.close(fd)
+        try:
+            graph.generate(target, self._trace, graph_format='json')
+            with target.open('r', encoding='utf-8') as fp:
+                obj = json.load(fp)
+            expected = {
+                'packages': [{'name': 'pkg1', 'version': '1.0',
+                              'files': ['/usr/bin/wc']},
+                             {'name': 'pkg2', 'version': '1.0',
+                              'files': ['/etc/2_two.cfg',
+                                        '/usr/lib/2_one.so']},
+                             {'name': 'python', 'version': '2.7',
+                              'files': ['/usr/bin/python']}],
+                'other_files': ['/bin/sh',
+                                '/some/dir/drive.py',
+                                '/some/dir/experiment',
+                                '/some/dir/one',
+                                '/some/dir/report',
+                                '/some/dir/result',
+                                '/some/dir/thing',
+                                '/some/dir/two',
+                                '/usr/share/1_one.pyc'],
+                'runs': [[{'name': '0',
+                           'long_name': 'sh (0)',
+                           'description': '/bin/sh\n0',
+                           'parent': None,
+                           'reads': ['/bin/sh', '/usr/share/1_one.pyc'],
+                           'writes': ['/some/dir/one']},
+                          {'name': '0',
+                           'long_name': 'python (0)',
+                           'description': '/usr/bin/python\n0',
+                           'parent': [0, 'exec'],
+                           'reads': ['/usr/bin/python',
+                                     '/some/dir/drive.py',
+                                     '/some/dir/one',
+                                     '/etc/2_two.cfg'],
+                           'writes': []},
+                          {'name': '1',
+                           'long_name': 'experiment (1)',
+                           'description': '/some/dir/experiment\n1',
+                           'parent': [1, 'fork+exec'],
+                           'reads': ['/some/dir/experiment',
+                                     '/usr/lib/2_one.so'],
+                           'writes': ['/some/dir/two']},
+                          {'name': '0',
+                           'long_name': 'wc (0)',
+                           'description': '/usr/bin/wc\n0',
+                           'parent': [1, 'exec'],
+                           'reads': ['/usr/bin/wc', '/some/dir/two'],
+                           'writes': []}],
+
+                         [{'name': '2',
+                           'long_name': 'sh (2)',
+                           'description': '/bin/sh\n2',
+                           'parent': None,
+                           'reads': ['/bin/sh'],
+                           'writes': []},
+                          {'name': '3',
+                           'long_name': 'python (3)',
+                           'description': '/usr/bin/python\n3',
+                           'parent': [0, 'fork+exec'],
+                           'reads': ['/usr/bin/python', '/some/dir/one'],
+                           'writes': ['/some/dir/thing']},
+                          {'name': '2',
+                           'long_name': 'report (2)',
+                           'description': '/some/dir/report\n2',
+                           'parent': [0, 'exec'],
+                           'reads': ['/some/dir/report', '/some/dir/thing'],
+                           'writes': ['/some/dir/result']}]]}
+            self.assertEqual(expected, obj)
+        finally:
+            target.remove()

--- a/tests/test_graph.py
+++ b/tests/test_graph.py
@@ -7,6 +7,7 @@ from __future__ import print_function, unicode_literals
 import json
 import os
 from rpaths import Path
+import sys
 import unittest
 
 from reprounzip.common import FILE_READ, FILE_WRITE, FILE_WDIR, FILE_STAT
@@ -21,6 +22,9 @@ class TestGraph(unittest.TestCase):
 
     @classmethod
     def setUpClass(cls):
+        if sys.version_info < (2, 7, 3):
+            raise unittest.SkipTest("Python version not supported by reprozip")
+
         cls._trace = Path.tempdir(prefix='rpz_testdb_')
         conn = make_database([
             ('proc', 0, None, False),

--- a/tests/test_reprozip.py
+++ b/tests/test_reprozip.py
@@ -163,14 +163,15 @@ class TestFiles(unittest.TestCase):
 
     def test_get_files(self):
         files, inputs, outputs = self.do_test([
-            ('proc', 0, None),
+            ('proc', 0, None, False),
             ('open', 0, "/some/dir", True, FILE_WDIR),
             ('exec', 0, "/some/dir/ls", "/some/dir", "ls\0"),
             ('open', 0, "/some/otherdir/in", False, FILE_READ),
             ('open', 0, "/some/thing/created", True, FILE_WRITE),
-            ('open', 0, "/some/thing/created/file", False, FILE_WRITE),
-            ('open', 0, "/some/thing/created/file", False, FILE_READ),
-            ('open', 0, "/some/thing/created", True, FILE_WDIR),
+            ('proc', 1, 0, False),
+            ('open', 1, "/some/thing/created/file", False, FILE_WRITE),
+            ('open', 1, "/some/thing/created/file", False, FILE_READ),
+            ('open', 1, "/some/thing/created", True, FILE_WDIR),
             ('exec', 0, "/some/thing/created/file", "/some/thing/created",
              "created\0"),
         ])
@@ -191,17 +192,18 @@ class TestFiles(unittest.TestCase):
         Path.stat = fail
         try:
             files, inputs, outputs = self.do_test([
-                ('proc', 0, None),
+                ('proc', 0, None, False),
                 ('open', 0, "/some/dir", True, FILE_WDIR),
                 ('exec', 0, "/some/dir/ls", "/some/dir", b'ls\0/some/cli\0'),
                 ('open', 0, "/some/cli", False, FILE_WRITE),
                 ('open', 0, "/some/r", False, FILE_READ),
                 ('open', 0, "/some/rw", False, FILE_READ),
-                ('proc', 1, None),
+                ('proc', 1, None, False),
                 ('open', 1, "/some/dir", True, FILE_WDIR),
                 ('exec', 1, "/some/dir/ls", "/some/dir", b'ls\0'),
                 ('open', 1, "/some/cli", False, FILE_READ),
-                ('open', 1, "/some/r", False, FILE_READ),
+                ('proc', 2, 1, True),
+                ('open', 2, "/some/r", False, FILE_READ),
                 ('open', 1, "/some/rw", False, FILE_WRITE),
             ])
             expected = set([

--- a/tests/test_reprozip.py
+++ b/tests/test_reprozip.py
@@ -6,13 +6,14 @@ from __future__ import print_function, unicode_literals
 
 import os
 from rpaths import AbstractPath, Path
-import sqlite3
 import sys
 import unittest
 
 from reprozip.common import FILE_READ, FILE_WRITE, FILE_WDIR, InputOutputFile
 from reprozip.tracer.trace import get_files, compile_inputs_outputs
 from reprozip.utils import unicode_, UniqueNames, make_dir_writable
+
+from tests.common import make_database
 
 
 class TestReprozip(unittest.TestCase):
@@ -134,88 +135,7 @@ class TestNames(unittest.TestCase):
 
 class TestFiles(unittest.TestCase):
     def do_test(self, insert):
-        conn = sqlite3.connect('')
-        conn.row_factory = sqlite3.Row
-        conn.execute(
-                '''
-                CREATE TABLE processes(
-                    id INTEGER NOT NULL PRIMARY KEY,
-                    run_id INTEGER NOT NULL,
-                    parent INTEGER,
-                    timestamp INTEGER NOT NULL,
-                    is_thread BOOLEAN NOT NULL,
-                    exitcode INTEGER
-                    );
-                ''')
-        conn.execute(
-                '''
-                CREATE INDEX proc_parent_idx ON processes(parent);
-                ''')
-        conn.execute(
-                '''
-                CREATE TABLE opened_files(
-                    id INTEGER NOT NULL PRIMARY KEY,
-                    run_id INTEGER NOT NULL,
-                    name TEXT NOT NULL,
-                    timestamp INTEGER NOT NULL,
-                    mode INTEGER NOT NULL,
-                    is_directory BOOLEAN NOT NULL,
-                    process INTEGER NOT NULL
-                    );
-                ''')
-        conn.execute(
-                '''
-                CREATE INDEX open_proc_idx ON opened_files(process);
-                ''')
-        conn.execute(
-                '''
-                CREATE TABLE executed_files(
-                    id INTEGER NOT NULL PRIMARY KEY,
-                    name TEXT NOT NULL,
-                    run_id INTEGER NOT NULL,
-                    timestamp INTEGER NOT NULL,
-                    process INTEGER NOT NULL,
-                    argv TEXT NOT NULL,
-                    envp TEXT NOT NULL,
-                    workingdir TEXT NOT NULL
-                    );
-                ''')
-        conn.execute(
-                '''
-                CREATE INDEX exec_proc_idx ON executed_files(process);
-                ''')
-
-        for timestamp, l in enumerate(insert):
-            if l[0] == 'proc':
-                ident, parent, = l[1:]
-                conn.execute(
-                        '''
-                        INSERT INTO processes(id, run_id, parent, timestamp,
-                                              is_thread, exitcode)
-                        VALUES(?, 0, ?, ?, 0, 0);
-                        ''',
-                        (ident, parent, timestamp))
-            elif l[0] == 'open':
-                process, name, is_dir, mode = l[1:]
-                conn.execute(
-                        '''
-                        INSERT INTO opened_files(run_id, name, timestamp, mode,
-                                                 is_directory, process)
-                        VALUES(0, ?, ?, ?, ?, ?);
-                        ''',
-                        (name, timestamp, mode, is_dir, process))
-            elif l[0] == 'exec':
-                process, name, wdir, argv = l[1:]
-                conn.execute(
-                        '''
-                        INSERT INTO executed_files(run_id, name, timestamp,
-                                                   process, argv, envp,
-                                                   workingdir)
-                        VALUES(0, ?, ?, ?, ?, "", ?);
-                        ''',
-                        (name, timestamp, process, argv, wdir))
-            else:
-                assert False
+        conn = make_database(insert)
 
         try:
             files, inputs, outputs = get_files(conn)

--- a/tests/test_reprozip.py
+++ b/tests/test_reprozip.py
@@ -165,14 +165,14 @@ class TestFiles(unittest.TestCase):
         files, inputs, outputs = self.do_test([
             ('proc', 0, None),
             ('open', 0, "/some/dir", True, FILE_WDIR),
-            ('exec', 0, "/some/dir/ls", "/some/dir", b"ls\0"),
+            ('exec', 0, "/some/dir/ls", "/some/dir", "ls\0"),
             ('open', 0, "/some/otherdir/in", False, FILE_READ),
             ('open', 0, "/some/thing/created", True, FILE_WRITE),
             ('open', 0, "/some/thing/created/file", False, FILE_WRITE),
             ('open', 0, "/some/thing/created/file", False, FILE_READ),
             ('open', 0, "/some/thing/created", True, FILE_WDIR),
             ('exec', 0, "/some/thing/created/file", "/some/thing/created",
-             b"created\0"),
+             "created\0"),
         ])
         expected = set([
             '/some/dir',


### PR DESCRIPTION
This allows to generate graphs that are not too huge to be rendered.

* Processes can be either:
  * Every process and thread
  * Only processes (aggregate threads)
  * Only runs (aggregate all the processes of each run)
* Packages can be either:
  * Every file of every package
  * Aggregate by package
  * Ignore packages (treat every file as an "other file")
* Other files can be either:
  * Every file
  * Only input & output files
  * Not shown

~~The DOT-writing code looks really weird, and should probably be refactored.~~