### PR TITLE
Turn some warning into info messages

### DIFF
--- a/reprozip/native/syscalls.c
+++ b/reprozip/native/syscalls.c
@@ -106,7 +106,7 @@ static int syscall_unhandled_path1(const char *name, struct Process *process,
      && name != NULL)
     {
         char *pathname = abs_path_arg(process, 0);
-        log_warn(process->tid, "process used unhandled system call %s(\"%s\")",
+        log_info(process->tid, "process used unhandled system call %s(\"%s\")",
                  name, pathname);
         free(pathname);
     }
@@ -118,7 +118,7 @@ static int syscall_unhandled_other(const char *name, struct Process *process,
 {
     if(verbosity >= 1 && process->in_syscall && process->retvalue.i >= 0
      && name != NULL)
-        log_warn(process->tid, "process used unhandled system call %s", name);
+        log_info(process->tid, "process used unhandled system call %s", name);
     return 0;
 }
 
@@ -600,7 +600,7 @@ static int handle_accept(struct Process *process,
     {
         void *address = malloc(addrlen);
         tracee_read(process->tid, address, arg1, addrlen);
-        log_warn(process->tid, "process accepted a connection from %s",
+        log_info(process->tid, "process accepted a connection from %s",
                  print_sockaddr(address, addrlen));
         free(address);
     }
@@ -614,7 +614,7 @@ static int handle_connect(struct Process *process,
     {
         void *address = malloc(addrlen);
         tracee_read(process->tid, address, arg1, addrlen);
-        log_warn(process->tid, "process connected to %s",
+        log_info(process->tid, "process connected to %s",
                  print_sockaddr(address, addrlen));
         free(address);
     }
@@ -714,7 +714,7 @@ static int syscall_xxx_at(const char *name, struct Process *process,
     else
     {
         char *pathname = tracee_strdup(process->tid, process->params[1].p);
-        log_warn(process->tid,
+        log_info(process->tid,
                  "process used unhandled system call %s(%d, \"%s\")",
                  name, process->params[0].i, pathname);
         free(pathname);

--- a/reprozip/native/tracer.c
+++ b/reprozip/native/tracer.c
@@ -538,9 +538,9 @@ static int trace(pid_t first_proc, int *first_exit_code)
             else if(signum == SIGTRAP)
             {
                 /* LCOV_EXCL_START : Processes shouldn't be getting SIGTRAPs */
-                log_warn(0,
-                         "NOT delivering SIGTRAP to %d\n"
-                         "    waitstatus=0x%X", tid, status);
+                log_error(0,
+                          "NOT delivering SIGTRAP to %d\n"
+                          "    waitstatus=0x%X", tid, status);
                 ptrace(PTRACE_SYSCALL, tid, NULL, NULL);
                 /* LCOV_EXCL_END */
             }


### PR DESCRIPTION
This makes the log messages about unhandled system calls being used, or the experiment connecting to servers or accepting connections, not display by default (need --verbose).

Fixes #128

The bad thing is that these messages might be interesting and give clues about reproducibility concerns. Of course they are still in `~/.reprozip/log`.

Interesting note: with this, there are no messages with level WARNING in the C tracer...