### PR TITLE
Pass-through environment variables from the host

### DIFF
--- a/reprounzip-docker/reprounzip/unpackers/docker.py
+++ b/reprounzip-docker/reprounzip/unpackers/docker.py
@@ -28,9 +28,9 @@ from reprounzip import signals
 from reprounzip.unpackers.common import COMPAT_OK, COMPAT_MAYBE, \
     CantFindInstaller, composite_action, target_must_exist, \
     make_unique_name, shell_escape, select_installer, busybox_url, sudo_url, \
-    FileUploader, FileDownloader, get_runs, interruptible_call, \
-    metadata_read, metadata_write, metadata_initial_iofiles, \
-    metadata_update_run
+    FileUploader, FileDownloader, get_runs, add_environment_options, \
+    fixup_environment, interruptible_call, metadata_read, metadata_write, \
+    metadata_initial_iofiles, metadata_update_run
 from reprounzip.unpackers.common.x11 import X11Handler, LocalForwarder
 from reprounzip.utils import unicode_, iteritems, stderr, join_root, \
     check_output, download_file
@@ -412,6 +412,7 @@ def docker_run(args):
         cmd = 'cd %s && ' % shell_escape(run['workingdir'])
         cmd += '/busybox env -i '
         environ = x11.fix_env(run['environ'])
+        environ = fixup_environment(environ, args)
         cmd += ' '.join('%s=%s' % (k, shell_escape(v))
                         for k, v in iteritems(environ))
         cmd += ' '
@@ -784,6 +785,7 @@ def setup(parser, **kwargs):
         help="Connect X11 to local machine from Docker container instead of "
              "trying to connect to this one (useful if the Docker machine has "
              "an X server or if a tunnel is used to access this one)")
+    add_environment_options(parser_run)
     parser_run.set_defaults(func=docker_run)
 
     # download

--- a/reprounzip-vagrant/reprounzip/unpackers/vagrant/__init__.py
+++ b/reprounzip-vagrant/reprounzip/unpackers/vagrant/__init__.py
@@ -28,7 +28,8 @@ from reprounzip import signals
 from reprounzip.unpackers.common import COMPAT_OK, COMPAT_MAYBE, COMPAT_NO, \
     CantFindInstaller, composite_action, target_must_exist, \
     make_unique_name, shell_escape, select_installer, busybox_url, join_root, \
-    FileUploader, FileDownloader, get_runs, metadata_read, metadata_write, \
+    FileUploader, FileDownloader, get_runs, add_environment_options, \
+    fixup_environment, metadata_read, metadata_write, \
     metadata_initial_iofiles, metadata_update_run
 from reprounzip.unpackers.common.x11 import X11Handler
 from reprounzip.unpackers.vagrant.run_command import IgnoreMissingKey, \
@@ -428,6 +429,7 @@ def vagrant_run(args):
         else:
             cmd += '/usr/bin/env -i '
         environ = x11.fix_env(run['environ'])
+        environ = fixup_environment(environ, args)
         cmd += ' '.join('%s=%s' % (k, shell_escape(v))
                         for k, v in iteritems(environ))
         cmd += ' '
@@ -786,6 +788,7 @@ def setup(parser, **kwargs):
                             help=("Display number to use on the experiment "
                                   "side (change the host display with the "
                                   "DISPLAY environment variable)"))
+    add_environment_options(parser_run)
     parser_run.set_defaults(func=vagrant_run)
 
     # download

--- a/reprounzip/reprounzip/unpackers/common/__init__.py
+++ b/reprounzip/reprounzip/unpackers/common/__init__.py
@@ -15,7 +15,8 @@ from reprounzip.unpackers.common.misc import UsageError, \
     COMPAT_OK, COMPAT_NO, COMPAT_MAYBE, \
     composite_action, target_must_exist, unique_names, \
     make_unique_name, shell_escape, load_config, busybox_url, sudo_url, \
-    FileUploader, FileDownloader, get_runs, interruptible_call, \
+    FileUploader, FileDownloader, get_runs, add_environment_options, \
+    fixup_environment, interruptible_call, \
     metadata_read, metadata_write, metadata_initial_iofiles, \
     metadata_update_run
 from reprounzip.unpackers.common.packages import THIS_DISTRIBUTION, \
@@ -29,5 +30,6 @@ __all__ = ['THIS_DISTRIBUTION', 'PKG_NOT_INSTALLED', 'select_installer',
            'make_unique_name', 'shell_escape', 'load_config', 'busybox_url',
            'sudo_url',
            'join_root', 'FileUploader', 'FileDownloader', 'get_runs',
+           'add_environment_options', 'fixup_environment',
            'interruptible_call', 'metadata_read', 'metadata_write',
            'metadata_initial_iofiles', 'metadata_update_run']

--- a/reprounzip/reprounzip/unpackers/common/misc.py
+++ b/reprounzip/reprounzip/unpackers/common/misc.py
@@ -373,6 +373,36 @@ def get_runs(runs, selected_runs, cmdline):
     return run_list
 
 
+def add_environment_options(parser):
+    parser.add_argument('--pass-env', action='append', default=[],
+                        help="Environment variable to pass through from the "
+                             "host (value from the original machine will be "
+                             "overridden; can be passed multiple times)")
+    parser.add_argument('--set-env', action='append', default=[],
+                        help="Environment variable to set (value from the "
+                             "original machine will be ignored; can be passed "
+                             "multiple times)")
+
+
+def fixup_environment(environ, args):
+    if not (args.pass_env or args.set_env):
+        return environ
+    environ = dict(environ)
+
+    for var in args.pass_env:
+        if var in os.environ:
+            environ[var] = os.environ[var]
+
+    for var in args.set_env:
+        if '=' in var:
+            var, value = var.split('=', 1)
+            environ[var] = value
+        else:
+            environ.pop(var, None)
+
+    return environ
+
+
 def interruptible_call(*args, **kwargs):
     assert signal.getsignal(signal.SIGINT) == signal.default_int_handler
     proc = [None]


### PR DESCRIPTION
It might be useful to let the experiment have some environment variables from the host, instead of dropping them or replacing the value with the packing machine's.

Example: `$OMPI_*`