### PR TITLE
Use requests to implement download_file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ Features:
 * Allow `download --all`
 * Add `--input` and `--output` to showfiles
 * Implement `vagrant suspend` command
+* Do file downloads with [requests](http://python-requests.org/)
 
 1.0.3 (2015-12-02)
 ------------------

--- a/reprounzip/reprounzip/utils.py
+++ b/reprounzip/reprounzip/utils.py
@@ -23,6 +23,7 @@ import locale
 import logging
 import operator
 import os
+import requests
 from rpaths import Path, PosixPath
 import stat
 import subprocess
@@ -56,8 +57,6 @@ PY3 = sys.version_info[0] == 3
 
 
 if PY3:
-    from urllib.error import HTTPError
-    from urllib.request import Request, urlopen
     izip = zip
     irange = range
     iteritems = dict.items
@@ -68,7 +67,6 @@ if PY3:
     stdin_bytes = sys.stdin.buffer
     stdout, stderr = sys.stdout, sys.stderr
 else:
-    from urllib2 import Request, HTTPError, urlopen
     izip = itertools.izip
     irange = xrange
     iteritems = dict.iteritems
@@ -436,7 +434,7 @@ def download_file(url, dest, cachename=None):
     if cachename is None:
         cachename = dest.components[-1]
 
-    request = Request(url)
+    headers = {}
 
     if 'XDG_CACHE_HOME' in os.environ:
         cache = Path(os.environ['XDG_CACHE_HOME'])
@@ -445,15 +443,22 @@ def download_file(url, dest, cachename=None):
     cache = cache / 'reprozip' / cachename
     if cache.exists():
         mtime = email.utils.formatdate(cache.mtime(), usegmt=True)
-        request.add_header('If-Modified-Since', mtime)
+        headers['If-Modified-Since'] = mtime
 
     cache.parent.mkdir(parents=True)
 
     try:
-        response = urlopen(request, timeout=2 if cache.exists() else 10)
-    except Exception as e:
+        response = requests.get(url, headers=headers,
+                                timeout=2 if cache.exists() else 10,
+                                stream=True)
+        response.raise_for_status()
+        if response.status_code == 304:
+            raise requests.HTTPError(
+                '304 File is up to date, no data returned',
+                response=response)
+    except requests.RequestException as e:
         if cache.exists():
-            if isinstance(e, HTTPError) and e.code == 304:
+            if e.response and e.response.status_code == 304:
                 logging.info("Download %s: cache is up to date", cachename)
             else:
                 logging.warning("Download %s: error downloading %s: %s",
@@ -466,7 +471,8 @@ def download_file(url, dest, cachename=None):
     logging.info("Download %s: downloading %s", cachename, url)
     try:
         with cache.open('wb') as f:
-            copyfile(response, f)
+            for chunk in response.iter_content(4096):
+                f.write(chunk)
         response.close()
     except Exception as e:  # pragma: no cover
         try:

--- a/reprounzip/setup.py
+++ b/reprounzip/setup.py
@@ -14,7 +14,8 @@ with io.open('README.rst', encoding='utf-8') as fp:
 req = [
     'PyYAML',
     'rpaths>=0.8',
-    'usagestats>=0.3']
+    'usagestats>=0.3',
+    'requests']
 if sys.version_info < (2, 7):
     req.append('argparse')
 setup(name='reprounzip',

--- a/reprozip/reprozip/utils.py
+++ b/reprozip/reprozip/utils.py
@@ -23,6 +23,7 @@ import locale
 import logging
 import operator
 import os
+import requests
 from rpaths import Path, PosixPath
 import stat
 import subprocess
@@ -56,8 +57,6 @@ PY3 = sys.version_info[0] == 3
 
 
 if PY3:
-    from urllib.error import HTTPError
-    from urllib.request import Request, urlopen
     izip = zip
     irange = range
     iteritems = dict.items
@@ -68,7 +67,6 @@ if PY3:
     stdin_bytes = sys.stdin.buffer
     stdout, stderr = sys.stdout, sys.stderr
 else:
-    from urllib2 import Request, HTTPError, urlopen
     izip = itertools.izip
     irange = xrange
     iteritems = dict.iteritems
@@ -436,7 +434,7 @@ def download_file(url, dest, cachename=None):
     if cachename is None:
         cachename = dest.components[-1]
 
-    request = Request(url)
+    headers = {}
 
     if 'XDG_CACHE_HOME' in os.environ:
         cache = Path(os.environ['XDG_CACHE_HOME'])
@@ -445,15 +443,22 @@ def download_file(url, dest, cachename=None):
     cache = cache / 'reprozip' / cachename
     if cache.exists():
         mtime = email.utils.formatdate(cache.mtime(), usegmt=True)
-        request.add_header('If-Modified-Since', mtime)
+        headers['If-Modified-Since'] = mtime
 
     cache.parent.mkdir(parents=True)
 
     try:
-        response = urlopen(request, timeout=2 if cache.exists() else 10)
-    except Exception as e:
+        response = requests.get(url, headers=headers,
+                                timeout=2 if cache.exists() else 10,
+                                stream=True)
+        response.raise_for_status()
+        if response.status_code == 304:
+            raise requests.HTTPError(
+                '304 File is up to date, no data returned',
+                response=response)
+    except requests.RequestException as e:
         if cache.exists():
-            if isinstance(e, HTTPError) and e.code == 304:
+            if e.response and e.response.status_code == 304:
                 logging.info("Download %s: cache is up to date", cachename)
             else:
                 logging.warning("Download %s: error downloading %s: %s",
@@ -466,7 +471,8 @@ def download_file(url, dest, cachename=None):
     logging.info("Download %s: downloading %s", cachename, url)
     try:
         with cache.open('wb') as f:
-            copyfile(response, f)
+            for chunk in response.iter_content(4096):
+                f.write(chunk)
         response.close()
     except Exception as e:  # pragma: no cover
         try:

--- a/reprozip/setup.py
+++ b/reprozip/setup.py
@@ -39,7 +39,8 @@ with io.open('README.rst', encoding='utf-8') as fp:
 req = [
     'PyYAML',
     'rpaths>=0.8',
-    'usagestats>=0.3']
+    'usagestats>=0.3',
+    'requests']
 if sys.version_info < (2, 7):
     req.append('argparse')
 setup(name='reprozip',

--- a/scripts/conda/reprounzip/meta.yaml
+++ b/scripts/conda/reprounzip/meta.yaml
@@ -32,6 +32,7 @@ requirements:
     - python
     - setuptools  # for pkg_resources
     - pyyaml
+    - requests
     - rpaths >=0.8
     - usagestats >=0.3
 

--- a/scripts/conda/reprozip/meta.yaml
+++ b/scripts/conda/reprozip/meta.yaml
@@ -31,6 +31,7 @@ requirements:
   run:
     - python
     - pyyaml
+    - requests
     - rpaths >=0.8
     - usagestats >=0.3
 


### PR DESCRIPTION
This uses [requests](http://python-requests.org/) to download file, which is easier and more secure.

requests is already used in usagestats, so it makes sense to use it for everything.