### PR TITLE
Download parameters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ Features:
 * Allow `download --all`
 * Add `--input` and `--output` to showfiles
 * Implement `vagrant suspend` command
+* Do file downloads with [requests](http://python-requests.org/)
 
 1.0.3 (2015-12-02)
 ------------------

--- a/reprounzip/reprounzip/common.py
+++ b/reprounzip/reprounzip/common.py
@@ -608,12 +608,7 @@ def setup_usage_report(name, version):
     """
     global _usage_report
 
-    # Unpack CA certificate
-    fd, certificate_file = Path.tempfile(prefix='rpz_stats_ca_', suffix='.pem')
-    with certificate_file.open('wb') as fp:
-        fp.write(usage_report_ca)
-    os.close(fd)
-    atexit.register(os.remove, certificate_file.path)
+    certificate_file = get_reprozip_ca_certificate()
 
     _usage_report = usagestats.Stats(
         '~/.reprozip/usage_stats',
@@ -682,6 +677,17 @@ def submit_usage_report(**kwargs):
                          usagestats.OPERATING_SYSTEM,
                          usagestats.SESSION_TIME,
                          usagestats.PYTHON_VERSION)
+
+
+def get_reprozip_ca_certificate():
+    """Gets the ReproZip CA certificate filename.
+    """
+    fd, certificate_file = Path.tempfile(prefix='rpz_stats_ca_', suffix='.pem')
+    with certificate_file.open('wb') as fp:
+        fp.write(usage_report_ca)
+    os.close(fd)
+    atexit.register(os.remove, certificate_file.path)
+    return certificate_file
 
 
 usage_report_ca = b'''\

--- a/reprounzip/reprounzip/parameters.py
+++ b/reprounzip/reprounzip/parameters.py
@@ -1,0 +1,70 @@
+# Copyright (C) 2014-2016 New York University
+# This file is part of ReproZip which is released under the Revised BSD License
+# See file LICENSE for full license details.
+
+"""Retrieve parameters from online source.
+
+Most unpackers require some parameters that are likely to change on a different
+schedule from ReproZip's releases. To account for that, ReproZip downloads a
+"parameter file", which is just a JSON with a bunch of parameters.
+
+In there you will find things like the address of some binaries that are
+downloaded from the web (rpzsudo and busybox), and the name of Vagrant boxes
+and Docker images for various operating systems.
+"""
+
+from __future__ import division, print_function, unicode_literals
+
+import json
+import logging
+from rpaths import Path
+
+
+parameters = None
+
+
+def update_parameters():
+    """Try to download a new version of the parameter file.
+    """
+    global parameters
+    if parameters is not None:
+        return
+
+    # TODO
+
+
+def get_parameter(section):
+    """Get a parameter from the downloaded or default parameter file.
+    """
+    global parameters
+
+    if parameters is None:
+        update_parameters()
+        try:
+            fp = (Path('~/.reprozip').expand_user() / 'parameters.json').open()
+        except IOError:
+            logging.info("No parameters.json file, using bundled parameters")
+            parameters = json.loads(bundled_parameters)
+        else:
+            parameters = json.load(fp)
+            fp.close()
+
+    return parameters.get(section, None)
+
+
+bundled_parameters = (
+    '{\n'
+    '  "busybox_url": {\n'
+    '    "x86_64": "https://www.busybox.net/downloads/binaries/latest/busybox-'
+    'x86_64",\n'
+    '    "i686": "https://www.busybox.net/downloads/binaries/latest/busybox-i6'
+    '86"\n'
+    '  },\n'
+    '  "rpzsudo_url": {\n'
+    '    "x86_64": "https://github.com/remram44/static-sudo/releases/download/'
+    'current/rpzsudo-x86_64",\n'
+    '    "i686": "https://github.com/remram44/static-sudo/releases/download/cu'
+    'rrent/rpzsudo-i686"\n'
+    '  }\n'
+    '}\n'
+)

--- a/reprounzip/reprounzip/unpackers/common/misc.py
+++ b/reprounzip/reprounzip/unpackers/common/misc.py
@@ -23,6 +23,7 @@ import tarfile
 
 import reprounzip.common
 from reprounzip.common import RPZPack
+from reprounzip.parameters import get_parameter
 from reprounzip.utils import irange, iteritems, itervalues, stdout_bytes, \
     unicode_, join_root, copyfile
 
@@ -117,15 +118,13 @@ def load_config(pack):
 def busybox_url(arch):
     """Gets the correct URL for the busybox binary given the architecture.
     """
-    return ('https://www.busybox.net/downloads/binaries/latest/busybox-%s' %
-            arch)
+    return get_parameter('busybox_url')[arch]
 
 
 def sudo_url(arch):
     """Gets the correct URL for the rpzsudo binary given the architecture.
     """
-    return ('https://github.com/remram44/static-sudo'
-            '/releases/download/current/rpzsudo-%s' % arch)
+    return get_parameter('rpzsudo_url')[arch]
 
 
 class FileUploader(object):

--- a/reprounzip/reprounzip/utils.py
+++ b/reprounzip/reprounzip/utils.py
@@ -423,7 +423,7 @@ def copyfile(source, destination, CHUNK_SIZE=4096):
             break
 
 
-def download_file(url, dest, cachename=None):
+def download_file(url, dest, cachename=None, ssl_verify=None):
     """Downloads a file using a local cache.
 
     If the file cannot be downloaded or if it wasn't modified, the cached
@@ -452,7 +452,7 @@ def download_file(url, dest, cachename=None):
     try:
         response = requests.get(url, headers=headers,
                                 timeout=2 if cache.exists() else 10,
-                                stream=True)
+                                stream=True, verify=ssl_verify)
         response.raise_for_status()
         if response.status_code == 304:
             raise requests.HTTPError(

--- a/reprounzip/reprounzip/utils.py
+++ b/reprounzip/reprounzip/utils.py
@@ -23,6 +23,7 @@ import locale
 import logging
 import operator
 import os
+import requests
 from rpaths import Path, PosixPath
 import stat
 import subprocess
@@ -56,8 +57,6 @@ PY3 = sys.version_info[0] == 3
 
 
 if PY3:
-    from urllib.error import HTTPError
-    from urllib.request import Request, urlopen
     izip = zip
     irange = range
     iteritems = dict.items
@@ -68,7 +67,6 @@ if PY3:
     stdin_bytes = sys.stdin.buffer
     stdout, stderr = sys.stdout, sys.stderr
 else:
-    from urllib2 import Request, HTTPError, urlopen
     izip = itertools.izip
     irange = xrange
     iteritems = dict.iteritems
@@ -436,7 +434,7 @@ def download_file(url, dest, cachename=None):
     if cachename is None:
         cachename = dest.components[-1]
 
-    request = Request(url)
+    headers = {}
 
     if 'XDG_CACHE_HOME' in os.environ:
         cache = Path(os.environ['XDG_CACHE_HOME'])
@@ -445,15 +443,22 @@ def download_file(url, dest, cachename=None):
     cache = cache / 'reprozip' / cachename
     if cache.exists():
         mtime = email.utils.formatdate(cache.mtime(), usegmt=True)
-        request.add_header('If-Modified-Since', mtime)
+        headers['If-Modified-Since'] = mtime
 
     cache.parent.mkdir(parents=True)
 
     try:
-        response = urlopen(request, timeout=2 if cache.exists() else 10)
-    except Exception as e:
+        response = requests.get(url, headers=headers,
+                                timeout=2 if cache.exists() else 10,
+                                stream=True)
+        response.raise_for_status()
+        if response.status_code == 304:
+            raise requests.HTTPError(
+                '304 File is up to date, no data returned',
+                response=response)
+    except requests.RequestException as e:
         if cache.exists():
-            if isinstance(e, HTTPError) and e.code == 304:
+            if e.response and e.response.status_code == 304:
                 logging.info("Download %s: cache is up to date", cachename)
             else:
                 logging.warning("Download %s: error downloading %s: %s",
@@ -466,7 +471,8 @@ def download_file(url, dest, cachename=None):
     logging.info("Download %s: downloading %s", cachename, url)
     try:
         with cache.open('wb') as f:
-            copyfile(response, f)
+            for chunk in response.iter_content(4096):
+                f.write(chunk)
         response.close()
     except Exception as e:  # pragma: no cover
         try:

--- a/reprounzip/reprounzip/utils.py
+++ b/reprounzip/reprounzip/utils.py
@@ -432,6 +432,8 @@ def download_file(url, dest, cachename=None):
     The cache lives in ``~/.cache/reprozip/``.
     """
     if cachename is None:
+        if dest is None:
+            raise ValueError("One of 'dest' or 'cachename' must be specified")
         cachename = dest.components[-1]
 
     headers = {}
@@ -463,8 +465,11 @@ def download_file(url, dest, cachename=None):
             else:
                 logging.warning("Download %s: error downloading %s: %s",
                                 cachename, url, e)
-            cache.copy(dest)
-            return
+            if dest is not None:
+                cache.copy(dest)
+                return dest
+            else:
+                return cache
         else:
             raise
 
@@ -482,4 +487,8 @@ def download_file(url, dest, cachename=None):
         raise e
     logging.info("Downloaded %s successfully", cachename)
 
-    cache.copy(dest)
+    if dest is not None:
+        cache.copy(dest)
+        return dest
+    else:
+        return cache

--- a/reprounzip/setup.py
+++ b/reprounzip/setup.py
@@ -14,7 +14,8 @@ with io.open('README.rst', encoding='utf-8') as fp:
 req = [
     'PyYAML',
     'rpaths>=0.8',
-    'usagestats>=0.3']
+    'usagestats>=0.3',
+    'requests']
 if sys.version_info < (2, 7):
     req.append('argparse')
 setup(name='reprounzip',

--- a/reprozip/reprozip/common.py
+++ b/reprozip/reprozip/common.py
@@ -608,12 +608,7 @@ def setup_usage_report(name, version):
     """
     global _usage_report
 
-    # Unpack CA certificate
-    fd, certificate_file = Path.tempfile(prefix='rpz_stats_ca_', suffix='.pem')
-    with certificate_file.open('wb') as fp:
-        fp.write(usage_report_ca)
-    os.close(fd)
-    atexit.register(os.remove, certificate_file.path)
+    certificate_file = get_reprozip_ca_certificate()
 
     _usage_report = usagestats.Stats(
         '~/.reprozip/usage_stats',
@@ -682,6 +677,17 @@ def submit_usage_report(**kwargs):
                          usagestats.OPERATING_SYSTEM,
                          usagestats.SESSION_TIME,
                          usagestats.PYTHON_VERSION)
+
+
+def get_reprozip_ca_certificate():
+    """Gets the ReproZip CA certificate filename.
+    """
+    fd, certificate_file = Path.tempfile(prefix='rpz_stats_ca_', suffix='.pem')
+    with certificate_file.open('wb') as fp:
+        fp.write(usage_report_ca)
+    os.close(fd)
+    atexit.register(os.remove, certificate_file.path)
+    return certificate_file
 
 
 usage_report_ca = b'''\

--- a/reprozip/reprozip/utils.py
+++ b/reprozip/reprozip/utils.py
@@ -423,7 +423,7 @@ def copyfile(source, destination, CHUNK_SIZE=4096):
             break
 
 
-def download_file(url, dest, cachename=None):
+def download_file(url, dest, cachename=None, ssl_verify=None):
     """Downloads a file using a local cache.
 
     If the file cannot be downloaded or if it wasn't modified, the cached
@@ -452,7 +452,7 @@ def download_file(url, dest, cachename=None):
     try:
         response = requests.get(url, headers=headers,
                                 timeout=2 if cache.exists() else 10,
-                                stream=True)
+                                stream=True, verify=ssl_verify)
         response.raise_for_status()
         if response.status_code == 304:
             raise requests.HTTPError(

--- a/reprozip/reprozip/utils.py
+++ b/reprozip/reprozip/utils.py
@@ -23,6 +23,7 @@ import locale
 import logging
 import operator
 import os
+import requests
 from rpaths import Path, PosixPath
 import stat
 import subprocess
@@ -56,8 +57,6 @@ PY3 = sys.version_info[0] == 3
 
 
 if PY3:
-    from urllib.error import HTTPError
-    from urllib.request import Request, urlopen
     izip = zip
     irange = range
     iteritems = dict.items
@@ -68,7 +67,6 @@ if PY3:
     stdin_bytes = sys.stdin.buffer
     stdout, stderr = sys.stdout, sys.stderr
 else:
-    from urllib2 import Request, HTTPError, urlopen
     izip = itertools.izip
     irange = xrange
     iteritems = dict.iteritems
@@ -436,7 +434,7 @@ def download_file(url, dest, cachename=None):
     if cachename is None:
         cachename = dest.components[-1]
 
-    request = Request(url)
+    headers = {}
 
     if 'XDG_CACHE_HOME' in os.environ:
         cache = Path(os.environ['XDG_CACHE_HOME'])
@@ -445,15 +443,22 @@ def download_file(url, dest, cachename=None):
     cache = cache / 'reprozip' / cachename
     if cache.exists():
         mtime = email.utils.formatdate(cache.mtime(), usegmt=True)
-        request.add_header('If-Modified-Since', mtime)
+        headers['If-Modified-Since'] = mtime
 
     cache.parent.mkdir(parents=True)
 
     try:
-        response = urlopen(request, timeout=2 if cache.exists() else 10)
-    except Exception as e:
+        response = requests.get(url, headers=headers,
+                                timeout=2 if cache.exists() else 10,
+                                stream=True)
+        response.raise_for_status()
+        if response.status_code == 304:
+            raise requests.HTTPError(
+                '304 File is up to date, no data returned',
+                response=response)
+    except requests.RequestException as e:
         if cache.exists():
-            if isinstance(e, HTTPError) and e.code == 304:
+            if e.response and e.response.status_code == 304:
                 logging.info("Download %s: cache is up to date", cachename)
             else:
                 logging.warning("Download %s: error downloading %s: %s",
@@ -466,7 +471,8 @@ def download_file(url, dest, cachename=None):
     logging.info("Download %s: downloading %s", cachename, url)
     try:
         with cache.open('wb') as f:
-            copyfile(response, f)
+            for chunk in response.iter_content(4096):
+                f.write(chunk)
         response.close()
     except Exception as e:  # pragma: no cover
         try:

--- a/reprozip/reprozip/utils.py
+++ b/reprozip/reprozip/utils.py
@@ -432,6 +432,8 @@ def download_file(url, dest, cachename=None):
     The cache lives in ``~/.cache/reprozip/``.
     """
     if cachename is None:
+        if dest is None:
+            raise ValueError("One of 'dest' or 'cachename' must be specified")
         cachename = dest.components[-1]
 
     headers = {}
@@ -463,8 +465,11 @@ def download_file(url, dest, cachename=None):
             else:
                 logging.warning("Download %s: error downloading %s: %s",
                                 cachename, url, e)
-            cache.copy(dest)
-            return
+            if dest is not None:
+                cache.copy(dest)
+                return dest
+            else:
+                return cache
         else:
             raise
 
@@ -482,4 +487,8 @@ def download_file(url, dest, cachename=None):
         raise e
     logging.info("Downloaded %s successfully", cachename)
 
-    cache.copy(dest)
+    if dest is not None:
+        cache.copy(dest)
+        return dest
+    else:
+        return cache

--- a/reprozip/setup.py
+++ b/reprozip/setup.py
@@ -39,7 +39,8 @@ with io.open('README.rst', encoding='utf-8') as fp:
 req = [
     'PyYAML',
     'rpaths>=0.8',
-    'usagestats>=0.3']
+    'usagestats>=0.3',
+    'requests']
 if sys.version_info < (2, 7):
     req.append('argparse')
 setup(name='reprozip',

--- a/scripts/conda/reprounzip/meta.yaml
+++ b/scripts/conda/reprounzip/meta.yaml
@@ -32,6 +32,7 @@ requirements:
     - python
     - setuptools  # for pkg_resources
     - pyyaml
+    - requests
     - rpaths >=0.8
     - usagestats >=0.3
 

--- a/scripts/conda/reprozip/meta.yaml
+++ b/scripts/conda/reprozip/meta.yaml
@@ -31,6 +31,7 @@ requirements:
   run:
     - python
     - pyyaml
+    - requests
     - rpaths >=0.8
     - usagestats >=0.3
 


### PR DESCRIPTION
Depends on requests, #173

This downloads a small `parameters.json` file that will contain things like busybox and rpzsudo URLs, Vagrant boxes and Docker images mappings, etc so that these can be updated without doing a release (and without people having to upgrade).

I'm probably hosting this on `reprozip-stats.poly.edu` since it's there and I have the certificate trickery working.