### PR TITLE
Log on non-root logger

### DIFF
--- a/reprounzip-docker/reprounzip/unpackers/docker.py
+++ b/reprounzip-docker/reprounzip/unpackers/docker.py
@@ -70,7 +70,7 @@ def select_image(runs):
 
     if architecture == 'i686':
         logger.info("Wanted architecture was i686, but we'll use x86_64 with "
-                     "Docker")
+                    "Docker")
     elif architecture != 'x86_64':
         logger.error("Error: unsupported architecture %s", architecture)
         sys.exit(1)
@@ -86,7 +86,7 @@ def select_image(runs):
                     return result
         distrib = images[default]
         logger.warning("Unsupported distribution '%s', using %s",
-                        distribution, default)
+                       distribution, default)
         return find_version(distrib, None)
 
     def find_version(distrib, version):
@@ -97,7 +97,7 @@ def select_image(runs):
         image = distrib['default']
         if version is not None:
             logger.warning("Using %s instead of '%s'",
-                            image['name'], version)
+                           image['name'], version)
         return image['distribution'], image['image']
 
     return find_distribution(get_parameter('docker_images'),
@@ -200,15 +200,15 @@ def docker_setup_create(args):
                                                  target_distribution)
                 except CantFindInstaller as e:
                     logger.error("Need to install %d packages but couldn't "
-                                  "select a package installer: %s",
-                                  len(packages), e)
+                                 "select a package installer: %s",
+                                 len(packages), e)
                     sys.exit(1)
                 # Updates package sources
                 fp.write('    %s && \\\n' % installer.update_script())
                 # Installs necessary packages
                 fp.write('    %s && \\\n' % installer.install_script(packages))
                 logger.info("Dockerfile will install the %d software "
-                             "packages that were not packed", len(packages))
+                            "packages that were not packed", len(packages))
             else:
                 record_usage(docker_install_pkgs=False)
 
@@ -302,13 +302,13 @@ def docker_reset(args):
 
     if image == initial:
         logger.warning("Image is already in the initial state, nothing to "
-                        "reset")
+                       "reset")
     else:
         logger.info("Removing image %s", image.decode('ascii'))
         retcode = subprocess.call(['docker', 'rmi', image])
         if retcode != 0:
             logger.warning("Can't remove previous image, docker returned %d",
-                            retcode)
+                           retcode)
         unpacked_info['current_image'] = initial
         write_dict(target, unpacked_info)
 
@@ -469,14 +469,14 @@ def docker_run(args):
     if (outjson[0]["State"]["Running"] is not False or
             outjson[0]["State"]["Paused"] is not False):
         logger.error("Invalid container state after execution:\n%s",
-                      json.dumps(outjson[0]["State"]))
+                     json.dumps(outjson[0]["State"]))
     retcode = outjson[0]["State"]["ExitCode"]
     stderr.write("\n*** Command finished, status: %d\n" % retcode)
 
     # Commit to create new image
     new_image = make_unique_name(b'reprounzip_image_')
     logger.info("Committing container %s to image %s",
-                 container.decode('ascii'), new_image.decode('ascii'))
+                container.decode('ascii'), new_image.decode('ascii'))
     subprocess.check_call(['docker', 'commit', container, new_image])
 
     # Update image name
@@ -563,11 +563,11 @@ class ContainerUploader(FileUploader):
             logger.info("New image created: %s", image.decode('ascii'))
             if from_image != self.unpacked_info['initial_image']:
                 logger.info("Untagging previous image %s",
-                             from_image.decode('ascii'))
+                            from_image.decode('ascii'))
                 retcode = subprocess.call(['docker', 'rmi', from_image])
                 if retcode != 0:
                     logger.warning("Can't remove previous image, docker "
-                                    "returned %d", retcode)
+                                   "returned %d", retcode)
             self.unpacked_info['current_image'] = image
             write_dict(self.target, self.unpacked_info)
 
@@ -623,7 +623,7 @@ class ContainerDownloader(FileDownloader):
         retcode = subprocess.call(['docker', 'rm', self.container])
         if retcode != 0:
             logger.warning("Can't remove temporary container, docker "
-                            "returned %d", retcode)
+                           "returned %d", retcode)
 
 
 @target_must_exist

--- a/reprounzip-docker/reprounzip/unpackers/docker.py
+++ b/reprounzip-docker/reprounzip/unpackers/docker.py
@@ -37,6 +37,9 @@ from reprounzip.utils import unicode_, iteritems, stderr, join_root, \
     download_file
 
 
+logger = logging.getLogger('reprounzip.docker')
+
+
 # How this all works:
 #  - setup/create just copies file to the target directory and writes the
 #    Dockerfile

--- a/reprounzip-docker/reprounzip/unpackers/docker.py
+++ b/reprounzip-docker/reprounzip/unpackers/docker.py
@@ -69,10 +69,10 @@ def select_image(runs):
                                                  architecture))
 
     if architecture == 'i686':
-        logging.info("Wanted architecture was i686, but we'll use x86_64 with "
+        logger.info("Wanted architecture was i686, but we'll use x86_64 with "
                      "Docker")
     elif architecture != 'x86_64':
-        logging.error("Error: unsupported architecture %s", architecture)
+        logger.error("Error: unsupported architecture %s", architecture)
         sys.exit(1)
 
     def find_distribution(parameter, distribution, version):
@@ -85,7 +85,7 @@ def select_image(runs):
                 if result is not None:
                     return result
         distrib = images[default]
-        logging.warning("Unsupported distribution '%s', using %s",
+        logger.warning("Unsupported distribution '%s', using %s",
                         distribution, default)
         return find_version(distrib, None)
 
@@ -96,7 +96,7 @@ def select_image(runs):
                     return image['distribution'], image['image']
         image = distrib['default']
         if version is not None:
-            logging.warning("Using %s instead of '%s'",
+            logger.warning("Using %s instead of '%s'",
                             image['name'], version)
         return image['distribution'], image['image']
 
@@ -131,7 +131,7 @@ def docker_setup_create(args):
     pack = Path(args.pack[0])
     target = Path(args.target[0])
     if target.exists():
-        logging.critical("Target directory exists")
+        logger.critical("Target directory exists")
         sys.exit(1)
 
     signals.pre_setup(target=target, pack=pack)
@@ -156,15 +156,15 @@ def docker_setup_create(args):
                 target_distribution = None
         else:
             target_distribution, base_image = select_image(runs)
-        logging.info("Using base image %s", base_image)
-        logging.debug("Distribution: %s", target_distribution or "unknown")
+        logger.info("Using base image %s", base_image)
+        logger.debug("Distribution: %s", target_distribution or "unknown")
 
         rpz_pack.copy_data_tar(target / 'data.tgz')
 
         arch = runs[0]['architecture']
 
         # Writes Dockerfile
-        logging.info("Writing %s...", target / 'Dockerfile')
+        logger.info("Writing %s...", target / 'Dockerfile')
         with (target / 'Dockerfile').open('w', encoding='utf-8',
                                           newline='\n') as fp:
             fp.write('FROM %s\n\n' % base_image)
@@ -199,7 +199,7 @@ def docker_setup_create(args):
                     installer = select_installer(pack, runs,
                                                  target_distribution)
                 except CantFindInstaller as e:
-                    logging.error("Need to install %d packages but couldn't "
+                    logger.error("Need to install %d packages but couldn't "
                                   "select a package installer: %s",
                                   len(packages), e)
                     sys.exit(1)
@@ -207,7 +207,7 @@ def docker_setup_create(args):
                 fp.write('    %s && \\\n' % installer.update_script())
                 # Installs necessary packages
                 fp.write('    %s && \\\n' % installer.install_script(packages))
-                logging.info("Dockerfile will install the %d software "
+                logger.info("Dockerfile will install the %d software "
                              "packages that were not packed", len(packages))
             else:
                 record_usage(docker_install_pkgs=False)
@@ -228,7 +228,7 @@ def docker_setup_create(args):
                     try:
                         rpz_pack.get_data(path)
                     except KeyError:
-                        logging.info("Missing file %s", path)
+                        logger.info("Missing file %s", path)
                     else:
                         pathlist.append(path)
             rpz_pack.close()
@@ -261,24 +261,24 @@ def docker_setup_build(args):
     target = Path(args.target[0])
     unpacked_info = read_dict(target)
     if 'initial_image' in unpacked_info:
-        logging.critical("Image already built")
+        logger.critical("Image already built")
         sys.exit(1)
 
     image = make_unique_name(b'reprounzip_image_')
 
-    logging.info("Calling 'docker build'...")
+    logger.info("Calling 'docker build'...")
     try:
         retcode = subprocess.call(['docker', 'build', '-t'] +
                                   args.docker_option + [image, '.'],
                                   cwd=target.path)
     except OSError:
-        logging.critical("docker executable not found")
+        logger.critical("docker executable not found")
         sys.exit(1)
     else:
         if retcode != 0:
-            logging.critical("docker build failed with code %d", retcode)
+            logger.critical("docker build failed with code %d", retcode)
             sys.exit(1)
-    logging.info("Initial image created: %s", image.decode('ascii'))
+    logger.info("Initial image created: %s", image.decode('ascii'))
 
     unpacked_info['initial_image'] = image
     unpacked_info['current_image'] = image
@@ -295,19 +295,19 @@ def docker_reset(args):
     target = Path(args.target[0])
     unpacked_info = read_dict(target)
     if 'initial_image' not in unpacked_info:
-        logging.critical("Image doesn't exist yet, have you run setup/build?")
+        logger.critical("Image doesn't exist yet, have you run setup/build?")
         sys.exit(1)
     image = unpacked_info['current_image']
     initial = unpacked_info['initial_image']
 
     if image == initial:
-        logging.warning("Image is already in the initial state, nothing to "
+        logger.warning("Image is already in the initial state, nothing to "
                         "reset")
     else:
-        logging.info("Removing image %s", image.decode('ascii'))
+        logger.info("Removing image %s", image.decode('ascii'))
         retcode = subprocess.call(['docker', 'rmi', image])
         if retcode != 0:
-            logging.warning("Can't remove previous image, docker returned %d",
+            logger.warning("Can't remove previous image, docker returned %d",
                             retcode)
         unpacked_info['current_image'] = initial
         write_dict(target, unpacked_info)
@@ -378,9 +378,9 @@ def docker_run(args):
     # Get current image name
     if 'current_image' in unpacked_info:
         image = unpacked_info['current_image']
-        logging.debug("Running from image %s", image.decode('ascii'))
+        logger.debug("Running from image %s", image.decode('ascii'))
     else:
-        logging.critical("Image doesn't exist yet, have you run setup/build?")
+        logger.critical("Image doesn't exist yet, have you run setup/build?")
         sys.exit(1)
 
     # Name of new container
@@ -409,7 +409,7 @@ def docker_run(args):
                 ssh_cmdline = ' '.join(
                     '-R*:%(p)d:127.0.0.1:%(p)d' % {'p': port}
                     for port, connector in x11.port_forward)
-                logging.warning(
+                logger.warning(
                     "You requested X11 forwarding but the Docker container "
                     "appears to be running remotely. It is probable that it "
                     "won't be able to connect to the local display. Creating "
@@ -452,14 +452,14 @@ def docker_run(args):
         forwarders.append(LocalForwarder(connector, port))
 
     # Run command in container
-    logging.info("Starting container %s", container.decode('ascii'))
+    logger.info("Starting container %s", container.decode('ascii'))
     retcode = interruptible_call(['docker', 'run', b'--name=' + container,
                                   '-h', hostname,
                                   '-i', '-t'] +
                                  args.docker_option +
                                  [image, '/busybox', 'sh', '-c', cmds])
     if retcode != 0:
-        logging.critical("docker run failed with code %d", retcode)
+        logger.critical("docker run failed with code %d", retcode)
         subprocess.call(['docker', 'rm', '-f', container])
         sys.exit(1)
 
@@ -468,14 +468,14 @@ def docker_run(args):
     outjson = json.loads(out.decode('ascii'))
     if (outjson[0]["State"]["Running"] is not False or
             outjson[0]["State"]["Paused"] is not False):
-        logging.error("Invalid container state after execution:\n%s",
+        logger.error("Invalid container state after execution:\n%s",
                       json.dumps(outjson[0]["State"]))
     retcode = outjson[0]["State"]["ExitCode"]
     stderr.write("\n*** Command finished, status: %d\n" % retcode)
 
     # Commit to create new image
     new_image = make_unique_name(b'reprounzip_image_')
-    logging.info("Committing container %s to image %s",
+    logger.info("Committing container %s to image %s",
                  container.decode('ascii'), new_image.decode('ascii'))
     subprocess.check_call(['docker', 'commit', container, new_image])
 
@@ -484,14 +484,14 @@ def docker_run(args):
     write_dict(target, unpacked_info)
 
     # Remove the container
-    logging.info("Destroying container %s", container.decode('ascii'))
+    logger.info("Destroying container %s", container.decode('ascii'))
     retcode = subprocess.call(['docker', 'rm', container])
     if retcode != 0:
-        logging.error("Error deleting container %s", container.decode('ascii'))
+        logger.error("Error deleting container %s", container.decode('ascii'))
 
     # Untag previous image, unless it is the initial_image
     if image != unpacked_info['initial_image']:
-        logging.info("Untagging previous image %s", image.decode('ascii'))
+        logger.info("Untagging previous image %s", image.decode('ascii'))
         subprocess.check_call(['docker', 'rmi', image])
 
     # Update input file status
@@ -524,7 +524,7 @@ class ContainerUploader(FileUploader):
             name = stem + ('_%d' % nb).encode('ascii') + ext
         name = Path(name)
         local_path.copyfile(self.build_directory / name)
-        logging.info("Copied file %s to %s", local_path, name)
+        logger.info("Copied file %s to %s", local_path, name)
         self.docker_copy.append((name, input_path))
 
     def finalize(self):
@@ -557,16 +557,16 @@ class ContainerUploader(FileUploader):
         retcode = subprocess.call(['docker', 'build', '-t', image, '.'],
                                   cwd=self.build_directory.path)
         if retcode != 0:
-            logging.critical("docker build failed with code %d", retcode)
+            logger.critical("docker build failed with code %d", retcode)
             sys.exit(1)
         else:
-            logging.info("New image created: %s", image.decode('ascii'))
+            logger.info("New image created: %s", image.decode('ascii'))
             if from_image != self.unpacked_info['initial_image']:
-                logging.info("Untagging previous image %s",
+                logger.info("Untagging previous image %s",
                              from_image.decode('ascii'))
                 retcode = subprocess.call(['docker', 'rmi', from_image])
                 if retcode != 0:
-                    logging.warning("Can't remove previous image, docker "
+                    logger.warning("Can't remove previous image, docker "
                                     "returned %d", retcode)
             self.unpacked_info['current_image'] = image
             write_dict(self.target, self.unpacked_info)
@@ -597,7 +597,7 @@ class ContainerDownloader(FileDownloader):
     def prepare_download(self, files):
         # Create a container from the image
         self.container = make_unique_name(b'reprounzip_dl_')
-        logging.info("Creating container %s", self.container.decode('ascii'))
+        logger.info("Creating container %s", self.container.decode('ascii'))
         subprocess.check_call(['docker', 'create',
                                b'--name=' + self.container,
                                self.image])
@@ -611,7 +611,7 @@ class ContainerDownloader(FileDownloader):
                                   self.container + b':' + remote_path.path,
                                   tmpdir.path])
             if ret != 0:
-                logging.critical("Can't get output file: %s", remote_path)
+                logger.critical("Can't get output file: %s", remote_path)
                 return False
             (tmpdir / remote_path.name).copyfile(local_path)
         finally:
@@ -619,10 +619,10 @@ class ContainerDownloader(FileDownloader):
         return True
 
     def finalize(self):
-        logging.info("Removing container %s", self.container.decode('ascii'))
+        logger.info("Removing container %s", self.container.decode('ascii'))
         retcode = subprocess.call(['docker', 'rm', self.container])
         if retcode != 0:
-            logging.warning("Can't remove temporary container, docker "
+            logger.warning("Can't remove temporary container, docker "
                             "returned %d", retcode)
 
 
@@ -635,10 +635,10 @@ def docker_download(args):
     unpacked_info = read_dict(target)
 
     if 'current_image' not in unpacked_info:
-        logging.critical("Image doesn't exist yet, have you run setup/build?")
+        logger.critical("Image doesn't exist yet, have you run setup/build?")
         sys.exit(1)
     image = unpacked_info['current_image']
-    logging.debug("Downloading from image %s", image.decode('ascii'))
+    logger.debug("Downloading from image %s", image.decode('ascii'))
 
     ContainerDownloader(target, files, image, all_=args.all)
 
@@ -650,7 +650,7 @@ def docker_destroy_docker(args):
     target = Path(args.target[0])
     unpacked_info = read_dict(target)
     if 'initial_image' not in unpacked_info:
-        logging.critical("Image not created")
+        logger.critical("Image not created")
         sys.exit(1)
 
     initial_image = unpacked_info.pop('initial_image')
@@ -658,15 +658,15 @@ def docker_destroy_docker(args):
     if 'current_image' in unpacked_info:
         image = unpacked_info.pop('current_image')
         if image != initial_image:
-            logging.info("Destroying image %s...", image.decode('ascii'))
+            logger.info("Destroying image %s...", image.decode('ascii'))
             retcode = subprocess.call(['docker', 'rmi', image])
             if retcode != 0:
-                logging.error("Error deleting image %s", image.decode('ascii'))
+                logger.error("Error deleting image %s", image.decode('ascii'))
 
-    logging.info("Destroying image %s...", initial_image.decode('ascii'))
+    logger.info("Destroying image %s...", initial_image.decode('ascii'))
     retcode = subprocess.call(['docker', 'rmi', initial_image])
     if retcode != 0:
-        logging.error("Error deleting image %s", initial_image.decode('ascii'))
+        logger.error("Error deleting image %s", initial_image.decode('ascii'))
 
 
 @target_must_exist
@@ -676,7 +676,7 @@ def docker_destroy_dir(args):
     target = Path(args.target[0])
     read_dict(target)
 
-    logging.info("Removing directory %s...", target)
+    logger.info("Removing directory %s...", target)
     signals.pre_destroy(target=target)
     target.rmtree()
     signals.post_destroy(target=target)

--- a/reprounzip-vagrant/reprounzip/unpackers/vagrant/__init__.py
+++ b/reprounzip-vagrant/reprounzip/unpackers/vagrant/__init__.py
@@ -38,6 +38,9 @@ from reprounzip.unpackers.vagrant.run_command import IgnoreMissingKey, \
 from reprounzip.utils import unicode_, iteritems, stderr, download_file
 
 
+logger = logging.getLogger('reprounzip.vagrant')
+
+
 def rb_escape(s):
     """Given bl'a, returns 'bl\\'a'.
     """

--- a/reprounzip-vagrant/reprounzip/unpackers/vagrant/__init__.py
+++ b/reprounzip-vagrant/reprounzip/unpackers/vagrant/__init__.py
@@ -73,7 +73,7 @@ def select_box(runs):
                     return result
         distrib = boxes[default]
         logger.warning("Unsupported distribution '%s', using %s",
-                        distribution, default)
+                       distribution, default)
         return find_version(distrib, None, architecture)
 
     def find_version(distrib, version, architecture):
@@ -86,7 +86,7 @@ def select_box(runs):
         box = distrib['default']
         if version is not None:
             logger.warning("Using %s instead of '%s'",
-                            box['name'], version)
+                           box['name'], version)
         result = box['architectures'].get(architecture)
         if result is not None:
             return box['distribution'], result
@@ -95,7 +95,7 @@ def select_box(runs):
                                distribution, version, architecture)
     if result is None:
         logger.critical("Error: couldn't find a base box for required "
-                         "architecture")
+                        "architecture")
         sys.exit(1)
     return result
 
@@ -152,8 +152,8 @@ def machine_setup(target, use_chroot):
                 username=vagrant_info.get('user', 'vagrant'),
                 key_filename=key_file)
     logger.debug("SSH parameters from Vagrant: %s@%s:%s, key=%s",
-                  info['username'], info['hostname'], info['port'],
-                  info['key_filename'])
+                 info['username'], info['hostname'], info['port'],
+                 info['key_filename'])
 
     if use_chroot:
         # Mount directories
@@ -243,17 +243,17 @@ def vagrant_setup_create(args):
         if packages:
             record_usage(vagrant_install_pkgs=True)
             logger.info("Some packages were not packed, so we'll install and "
-                         "copy their files\n"
-                         "Packages that are missing:\n%s",
-                         ' '.join(pkg.name for pkg in packages))
+                        "copy their files\n"
+                        "Packages that are missing:\n%s",
+                        ' '.join(pkg.name for pkg in packages))
 
     if packages:
         try:
             installer = select_installer(pack, runs, target_distribution)
         except CantFindInstaller as e:
             logger.error("Need to install %d packages but couldn't select a "
-                          "package installer: %s",
-                          len(packages), e)
+                         "package installer: %s",
+                         len(packages), e)
 
     target.mkdir(parents=True)
 
@@ -490,8 +490,8 @@ class SSHUploader(FileUploader):
         try:
             ssh_info = machine_setup(self.target, self.use_chroot)
         except subprocess.CalledProcessError:
-            logger.critical("Failed to get the status of the machine -- is "
-                             "it running?")
+            logger.critical("Failed to get the status of the machine -- is it "
+                            "running?")
             sys.exit(1)
 
         # Connect with SSH
@@ -568,7 +568,7 @@ class SSHDownloader(FileDownloader):
             info = machine_setup(self.target, self.use_chroot)
         except subprocess.CalledProcessError:
             logger.critical("Failed to get the status of the machine -- is "
-                             "it running?")
+                            "it running?")
             sys.exit(1)
 
         # Connect with SSH
@@ -607,7 +607,7 @@ class SSHDownloader(FileDownloader):
             ltemp.rename(local_path)
         except OSError as e:
             logger.critical("Couldn't download output file: %s\n%s",
-                             remote_path, str(e))
+                            remote_path, str(e))
             ltemp.remove()
             return False
         return True
@@ -636,7 +636,7 @@ def vagrant_suspend(args):
     retcode = subprocess.call(['vagrant', 'suspend'], cwd=target.path)
     if retcode != 0:
         logger.critical("vagrant suspend failed with code %d, ignoring...",
-                         retcode)
+                        retcode)
 
 
 @target_must_exist
@@ -649,7 +649,7 @@ def vagrant_destroy_vm(args):
     retcode = subprocess.call(['vagrant', 'destroy', '-f'], cwd=target.path)
     if retcode != 0:
         logger.critical("vagrant destroy failed with code %d, ignoring...",
-                         retcode)
+                        retcode)
 
 
 @target_must_exist
@@ -685,7 +685,7 @@ def check_vagrant_version():
     if out[0] == 'vagrant':
         if LooseVersion(out[1]) < LooseVersion('1.1'):
             logger.error("Vagrant >=1.1 is required; detected version: %s",
-                          out[1])
+                         out[1])
             sys.exit(1)
     else:
         logger.error("Vagrant >=1.1 is required")

--- a/reprounzip-vagrant/reprounzip/unpackers/vagrant/run_command.py
+++ b/reprounzip-vagrant/reprounzip/unpackers/vagrant/run_command.py
@@ -155,7 +155,7 @@ def run_interactive(ssh_info, interactive, cmd, request_pty, forwarded_ports):
             chan.get_pty()
 
         # Execute command
-        logging.info("Connected via SSH, running command...")
+        logger.info("Connected via SSH, running command...")
         chan.exec_command(cmd)
 
         # Get output

--- a/reprounzip-vagrant/reprounzip/unpackers/vagrant/run_command.py
+++ b/reprounzip-vagrant/reprounzip/unpackers/vagrant/run_command.py
@@ -23,6 +23,9 @@ from reprounzip.unpackers.vagrant.interaction import interactive_shell
 from reprounzip.utils import irange, stdout_bytes
 
 
+logger = logging.getLogger('reprounzip.vagrant')
+
+
 class IgnoreMissingKey(MissingHostKeyPolicy):
     """Policy that just ignores missing SSH host keys.
 

--- a/reprounzip-vistrails/reprounzip/plugins/vistrails.py
+++ b/reprounzip-vistrails/reprounzip/plugins/vistrails.py
@@ -32,6 +32,9 @@ from reprounzip.utils import iteritems
 __version__ = '1.0.3'
 
 
+logger = logging.getLogger('reprounzip.vistrails')
+
+
 def escape_xml(s):
     """Escapes for XML.
     """

--- a/reprounzip-vistrails/reprounzip/plugins/vistrails.py
+++ b/reprounzip-vistrails/reprounzip/plugins/vistrails.py
@@ -287,12 +287,12 @@ def run_from_vistrails():
             cli_version = int(sys.argv[1])
         except ValueError:
             logger.info("Compatibility mode: reprounzip-vistrails didn't get "
-                         "a version number")
+                        "a version number")
     if cli_version != 1:
-        logger.critical("Unknown interface version %d; you are probably "
-                         "using a version of reprounzip-vistrails too old for "
-                         "your VisTrails package. Consider upgrading.",
-                         cli_version)
+        logger.critical("Unknown interface version %d; you are probably using "
+                        "a version of reprounzip-vistrails too old for your "
+                        "VisTrails package. Consider upgrading.",
+                        cli_version)
         sys.exit(1)
 
     parser = argparse.ArgumentParser()
@@ -325,7 +325,7 @@ def run_from_vistrails():
                                   cwd=args.directory)
 
     logger.info("reprounzip-vistrails calling reprounzip; dir=%s",
-                 args.directory)
+                args.directory)
 
     # Parses input files from the command-line
     upload_command = []

--- a/reprounzip-vistrails/reprounzip/plugins/vistrails.py
+++ b/reprounzip-vistrails/reprounzip/plugins/vistrails.py
@@ -219,7 +219,7 @@ def do_vistrails(target, pack=None, **kwargs):
 
     # Writes VisTrails workflow
     bundle = target / 'vistrails.vt'
-    logging.info("Writing VisTrails workflow %s...", bundle)
+    logger.info("Writing VisTrails workflow %s...", bundle)
     vtdir = Path.tempdir(prefix='reprounzip_vistrails_')
     ids = IdScope()
     try:
@@ -286,10 +286,10 @@ def run_from_vistrails():
         try:
             cli_version = int(sys.argv[1])
         except ValueError:
-            logging.info("Compatibility mode: reprounzip-vistrails didn't get "
+            logger.info("Compatibility mode: reprounzip-vistrails didn't get "
                          "a version number")
     if cli_version != 1:
-        logging.critical("Unknown interface version %d; you are probably "
+        logger.critical("Unknown interface version %d; you are probably "
                          "using a version of reprounzip-vistrails too old for "
                          "your VisTrails package. Consider upgrading.",
                          cli_version)
@@ -314,17 +314,17 @@ def run_from_vistrails():
 
     def cmd(lst, add=None):
         if add:
-            logging.info("cmd: %s %s", ' '.join(rpuz + lst), add)
+            logger.info("cmd: %s %s", ' '.join(rpuz + lst), add)
             string = ' '.join(shell_escape(a) for a in (rpuz + lst))
             string += ' ' + add
             subprocess.check_call(string, shell=True,
                                   cwd=args.directory)
         else:
-            logging.info("cmd: %s", ' '.join(rpuz + lst))
+            logger.info("cmd: %s", ' '.join(rpuz + lst))
             subprocess.check_call(rpuz + lst,
                                   cwd=args.directory)
 
-    logging.info("reprounzip-vistrails calling reprounzip; dir=%s",
+    logger.info("reprounzip-vistrails calling reprounzip; dir=%s",
                  args.directory)
 
     # Parses input files from the command-line

--- a/reprounzip/reprounzip/common.py
+++ b/reprounzip/reprounzip/common.py
@@ -579,10 +579,11 @@ def setup_logging(tag, verbosity):
     handler.setLevel(console_level)
     handler.setFormatter(formatter)
 
-    # Set up logger
-    logger = logging.root
-    logger.setLevel(min_level)
-    logger.addHandler(handler)
+    # Set up loggers
+    loggers = [logging.getLogger('reprozip'), logging.getLogger('reprounzip')]
+    for logger in loggers:
+        logger.setLevel(min_level)
+        logger.addHandler(handler)
 
     # File logger
     dotrpz = Path('~/.reprozip').expand_user()
@@ -599,7 +600,8 @@ def setup_logging(tag, verbosity):
     else:
         filehandler.setFormatter(formatter)
         filehandler.setLevel(file_level)
-        logger.addHandler(filehandler)
+        for logger in loggers:
+            logger.addHandler(filehandler)
 
 
 _usage_report = None

--- a/reprounzip/reprounzip/common.py
+++ b/reprounzip/reprounzip/common.py
@@ -39,6 +39,9 @@ from .utils import iteritems, itervalues, unicode_, stderr, UniqueNames, \
     copyfile
 
 
+logger = logging.getLogger(__name__.split('.', 1)[0])
+
+
 FILE_READ = 0x01
 FILE_WRITE = 0x02
 FILE_WDIR = 0x04

--- a/reprounzip/reprounzip/common.py
+++ b/reprounzip/reprounzip/common.py
@@ -333,16 +333,16 @@ def load_iofiles(config, runs):
         if name in files:
             if files[name].path != path:
                 old_name, name = name, uniquenames(name)
-                logging.warning("File name appears multiple times: %s\n"
+                logger.warning("File name appears multiple times: %s\n"
                                 "Using name %s instead",
                                 old_name, name)
         else:
             uniquenames.insert(name)
         if path in paths:
             if paths[path] == name:
-                logging.warning("File appears multiple times: %s", name)
+                logger.warning("File appears multiple times: %s", name)
             else:
-                logging.warning("Two files have the same path (but different "
+                logger.warning("Two files have the same path (but different "
                                 "names): %s, %s\nUsing name %s",
                                 name, paths[path], paths[path])
                 name = paths[path]
@@ -387,7 +387,7 @@ def load_config(filename, canonical, File=File, Package=Package):
                                 # Deprecated
                                 'input_files', 'output_files'])
     if unknown_keys:
-        logging.warning("Unrecognized sections in configuration: %s",
+        logger.warning("Unrecognized sections in configuration: %s",
                         ', '.join(unknown_keys))
 
     runs = config.get('runs') or []
@@ -599,7 +599,7 @@ def setup_logging(tag, verbosity):
                                                            maxBytes=400000,
                                                            backupCount=5)
     except (IOError, OSError):
-        logging.warning("Couldn't create log file %s", dotrpz / 'log')
+        logger.warning("Couldn't create log file %s", dotrpz / 'log')
     else:
         filehandler.setFormatter(formatter)
         filehandler.setLevel(file_level)

--- a/reprounzip/reprounzip/common.py
+++ b/reprounzip/reprounzip/common.py
@@ -334,8 +334,8 @@ def load_iofiles(config, runs):
             if files[name].path != path:
                 old_name, name = name, uniquenames(name)
                 logger.warning("File name appears multiple times: %s\n"
-                                "Using name %s instead",
-                                old_name, name)
+                               "Using name %s instead",
+                               old_name, name)
         else:
             uniquenames.insert(name)
         if path in paths:
@@ -343,8 +343,8 @@ def load_iofiles(config, runs):
                 logger.warning("File appears multiple times: %s", name)
             else:
                 logger.warning("Two files have the same path (but different "
-                                "names): %s, %s\nUsing name %s",
-                                name, paths[path], paths[path])
+                               "names): %s, %s\nUsing name %s",
+                               name, paths[path], paths[path])
                 name = paths[path]
             files[name].read_runs.update(readers)
             files[name].write_runs.update(writers)
@@ -388,7 +388,7 @@ def load_config(filename, canonical, File=File, Package=Package):
                                 'input_files', 'output_files'])
     if unknown_keys:
         logger.warning("Unrecognized sections in configuration: %s",
-                        ', '.join(unknown_keys))
+                       ', '.join(unknown_keys))
 
     runs = config.get('runs') or []
     packages = read_packages(config.get('packages'), File, Package)

--- a/reprounzip/reprounzip/main.py
+++ b/reprounzip/reprounzip/main.py
@@ -30,6 +30,9 @@ from reprounzip.unpackers.common import UsageError
 __version__ = '1.0.4'
 
 
+logger = logging.getLogger('reprounzip')
+
+
 unpackers = {}
 
 

--- a/reprounzip/reprounzip/main.py
+++ b/reprounzip/reprounzip/main.py
@@ -65,7 +65,7 @@ class RPUZArgumentParser(argparse.ArgumentParser):
 
 def usage_report(args):
     if bool(args.enable) == bool(args.disable):
-        logging.critical("What do you want to do?")
+        logger.critical("What do you want to do?")
         raise UsageError
     enable_usage_report(args.enable)
     sys.exit(0)

--- a/reprounzip/reprounzip/pack_info.py
+++ b/reprounzip/reprounzip/pack_info.py
@@ -82,11 +82,11 @@ def print_info(args):
         meta_architecture = runs[0]['architecture']
         if any(r['architecture'] != meta_architecture
                for r in runs):
-            logging.warning("Runs have different architectures")
+            logger.warning("Runs have different architectures")
         meta_distribution = runs[0]['distribution']
         if any(r['distribution'] != meta_distribution
                for r in runs):
-            logging.warning("Runs have different distributions")
+            logger.warning("Runs have different distributions")
         meta_distribution = ' '.join(t for t in meta_distribution if t)
 
     current_architecture = platform.machine().lower()
@@ -194,10 +194,10 @@ def showfiles(args):
         try:
             r = int(s)
         except ValueError:
-            logging.critical("Error: Unknown run %s", s)
+            logger.critical("Error: Unknown run %s", s)
             raise UsageError
         if r < 0 or r >= len(runs):
-            logging.critical("Error: Expected 0 <= run <= %d, got %d",
+            logger.critical("Error: Expected 0 <= run <= %d, got %d",
                              len(runs) - 1, r)
             sys.exit(1)
         return r
@@ -218,7 +218,7 @@ def showfiles(args):
     pack = Path(args.pack[0])
 
     if not pack.exists():
-        logging.critical("Pack or directory %s does not exist", pack)
+        logger.critical("Pack or directory %s does not exist", pack)
         sys.exit(1)
 
     if pack.is_dir():

--- a/reprounzip/reprounzip/pack_info.py
+++ b/reprounzip/reprounzip/pack_info.py
@@ -198,7 +198,7 @@ def showfiles(args):
             raise UsageError
         if r < 0 or r >= len(runs):
             logger.critical("Error: Expected 0 <= run <= %d, got %d",
-                             len(runs) - 1, r)
+                            len(runs) - 1, r)
             sys.exit(1)
         return r
 

--- a/reprounzip/reprounzip/pack_info.py
+++ b/reprounzip/reprounzip/pack_info.py
@@ -26,6 +26,9 @@ from reprounzip.unpackers.common import load_config, COMPAT_OK, COMPAT_MAYBE, \
 from reprounzip.utils import iteritems, itervalues, unicode_, hsize
 
 
+logger = logging.getLogger('reprounzip')
+
+
 def print_info(args):
     """Writes out some information about a pack file.
     """

--- a/reprounzip/reprounzip/parameters.py
+++ b/reprounzip/reprounzip/parameters.py
@@ -53,7 +53,7 @@ def update_parameters():
                 ssl_verify=get_reprozip_ca_certificate().path)
         except Exception:
             logger.info("Can't download parameters.json, using bundled "
-                         "parameters")
+                        "parameters")
         else:
             try:
                 with filename.open() as fp:
@@ -61,7 +61,7 @@ def update_parameters():
                 return
             except ValueError:
                 logger.info("Downloaded parameters.json doesn't load, using "
-                             "bundled parameters")
+                            "bundled parameters")
                 try:
                     filename.remove()
                 except OSError:

--- a/reprounzip/reprounzip/parameters.py
+++ b/reprounzip/reprounzip/parameters.py
@@ -23,6 +23,9 @@ from reprounzip.common import get_reprozip_ca_certificate
 from reprounzip.utils import download_file
 
 
+logger = logging.getLogger('reprounzip')
+
+
 parameters = None
 
 

--- a/reprounzip/reprounzip/parameters.py
+++ b/reprounzip/reprounzip/parameters.py
@@ -52,7 +52,7 @@ def update_parameters():
                 cachename='parameters.json',
                 ssl_verify=get_reprozip_ca_certificate().path)
         except Exception:
-            logging.info("Can't download parameters.json, using bundled "
+            logger.info("Can't download parameters.json, using bundled "
                          "parameters")
         else:
             try:
@@ -60,7 +60,7 @@ def update_parameters():
                     parameters = json.load(fp)
                 return
             except ValueError:
-                logging.info("Downloaded parameters.json doesn't load, using "
+                logger.info("Downloaded parameters.json doesn't load, using "
                              "bundled parameters")
                 try:
                     filename.remove()

--- a/reprounzip/reprounzip/unpackers/common/misc.py
+++ b/reprounzip/reprounzip/unpackers/common/misc.py
@@ -63,7 +63,7 @@ def target_must_exist(func):
     def wrapper(args):
         target = Path(args.target[0])
         if not target.is_dir():
-            logging.critical("Error: Target directory doesn't exist")
+            logger.critical("Error: Target directory doesn't exist")
             raise UsageError
         return func(args)
     return wrapper
@@ -171,7 +171,7 @@ class FileUploader(object):
             for filespec in files:
                 filespec_split = filespec.rsplit(':', 1)
                 if len(filespec_split) != 2:
-                    logging.critical("Invalid file specification: %r",
+                    logger.critical("Invalid file specification: %r",
                                      filespec)
                     sys.exit(1)
                 local_path, input_name = filespec_split
@@ -179,14 +179,14 @@ class FileUploader(object):
                 try:
                     input_path = input_files[input_name]
                 except KeyError:
-                    logging.critical("Invalid input file: %r", input_name)
+                    logger.critical("Invalid input file: %r", input_name)
                     sys.exit(1)
 
                 temp = None
 
                 if not local_path:
                     # Restore original file from pack
-                    logging.debug("Restoring input file %s", input_path)
+                    logger.debug("Restoring input file %s", input_path)
                     fd, temp = Path.tempfile(prefix='reprozip_input_')
                     os.close(fd)
                     local_path = self.extract_original_input(input_name,
@@ -194,15 +194,15 @@ class FileUploader(object):
                                                              temp)
                     if local_path is None:
                         temp.remove()
-                        logging.warning("No original packed, can't restore "
+                        logger.warning("No original packed, can't restore "
                                         "input file %s", input_name)
                         continue
                 else:
                     local_path = Path(local_path)
-                    logging.debug("Uploading file %s to %s",
+                    logger.debug("Uploading file %s to %s",
                                   local_path, input_path)
                     if not local_path.exists():
-                        logging.critical("Local file %s doesn't exist",
+                        logger.critical("Local file %s doesn't exist",
                                          local_path)
                         sys.exit(1)
 
@@ -273,7 +273,7 @@ class FileDownloader(object):
             elif len(filespec_split) == 2:
                 output_name, local_path = filespec_split
             else:
-                logging.critical("Invalid file specification: %r",
+                logger.critical("Invalid file specification: %r",
                                  filespec)
                 sys.exit(1)
             local_path = Path(local_path) if local_path else None
@@ -294,10 +294,10 @@ class FileDownloader(object):
                 try:
                     remote_path = output_files[output_name]
                 except KeyError:
-                    logging.critical("Invalid output file: %r", output_name)
+                    logger.critical("Invalid output file: %r", output_name)
                     sys.exit(1)
 
-                logging.debug("Downloading file %s", remote_path)
+                logger.debug("Downloading file %s", remote_path)
                 if local_path is None:
                     ret = self.download_and_print(remote_path)
                 else:
@@ -354,10 +354,10 @@ def get_runs(runs, selected_runs, cmdline):
         try:
             r = int(s)
         except ValueError:
-            logging.critical("Error: Unknown run %s", s)
+            logger.critical("Error: Unknown run %s", s)
             raise UsageError
         if r < 0 or r >= len(runs):
-            logging.critical("Error: Expected 0 <= run <= %d, got %d",
+            logger.critical("Error: Expected 0 <= run <= %d, got %d",
                              len(runs) - 1, r)
             sys.exit(1)
         return r
@@ -384,7 +384,7 @@ def get_runs(runs, selected_runs, cmdline):
                 else:
                     last = len(runs) - 1
                 if last < first:
-                    logging.critical("Error: Last run number should be "
+                    logger.critical("Error: Last run number should be "
                                      "greater than the first")
                     sys.exit(1)
                 run_list.extend(irange(first, last + 1))
@@ -473,7 +473,7 @@ def metadata_read(path, type_):
     with filename.open('rb') as fp:
         dct = pickle.load(fp)
     if type_ is not None and dct['unpacker'] != type_:
-        logging.critical("Wrong unpacker used: %s != %s",
+        logger.critical("Wrong unpacker used: %s != %s",
                          dct['unpacker'], type_)
         raise UsageError
     return dct

--- a/reprounzip/reprounzip/unpackers/common/misc.py
+++ b/reprounzip/reprounzip/unpackers/common/misc.py
@@ -30,6 +30,9 @@ from reprounzip.utils import irange, iteritems, itervalues, stdout_bytes, \
     unicode_, join_root, copyfile
 
 
+logger = logging.getLogger('reprounzip')
+
+
 COMPAT_OK = 0
 COMPAT_NO = 1
 COMPAT_MAYBE = 2

--- a/reprounzip/reprounzip/unpackers/common/misc.py
+++ b/reprounzip/reprounzip/unpackers/common/misc.py
@@ -171,8 +171,7 @@ class FileUploader(object):
             for filespec in files:
                 filespec_split = filespec.rsplit(':', 1)
                 if len(filespec_split) != 2:
-                    logger.critical("Invalid file specification: %r",
-                                     filespec)
+                    logger.critical("Invalid file specification: %r", filespec)
                     sys.exit(1)
                 local_path, input_name = filespec_split
 
@@ -195,15 +194,15 @@ class FileUploader(object):
                     if local_path is None:
                         temp.remove()
                         logger.warning("No original packed, can't restore "
-                                        "input file %s", input_name)
+                                       "input file %s", input_name)
                         continue
                 else:
                     local_path = Path(local_path)
                     logger.debug("Uploading file %s to %s",
-                                  local_path, input_path)
+                                 local_path, input_path)
                     if not local_path.exists():
                         logger.critical("Local file %s doesn't exist",
-                                         local_path)
+                                        local_path)
                         sys.exit(1)
 
                 self.upload_file(local_path, input_path)
@@ -274,7 +273,7 @@ class FileDownloader(object):
                 output_name, local_path = filespec_split
             else:
                 logger.critical("Invalid file specification: %r",
-                                 filespec)
+                                filespec)
                 sys.exit(1)
             local_path = Path(local_path) if local_path else None
             all_files.discard(output_name)
@@ -358,7 +357,7 @@ def get_runs(runs, selected_runs, cmdline):
             raise UsageError
         if r < 0 or r >= len(runs):
             logger.critical("Error: Expected 0 <= run <= %d, got %d",
-                             len(runs) - 1, r)
+                            len(runs) - 1, r)
             sys.exit(1)
         return r
 
@@ -384,8 +383,8 @@ def get_runs(runs, selected_runs, cmdline):
                 else:
                     last = len(runs) - 1
                 if last < first:
-                    logger.critical("Error: Last run number should be "
-                                     "greater than the first")
+                    logger.critical("Error: Last run number should be greater "
+                                    "than the first")
                     sys.exit(1)
                 run_list.extend(irange(first, last + 1))
 
@@ -474,7 +473,7 @@ def metadata_read(path, type_):
         dct = pickle.load(fp)
     if type_ is not None and dct['unpacker'] != type_:
         logger.critical("Wrong unpacker used: %s != %s",
-                         dct['unpacker'], type_)
+                        dct['unpacker'], type_)
         raise UsageError
     return dct
 

--- a/reprounzip/reprounzip/unpackers/common/packages.py
+++ b/reprounzip/reprounzip/unpackers/common/packages.py
@@ -15,6 +15,9 @@ from reprounzip.unpackers.common.misc import UsageError
 from reprounzip.utils import itervalues
 
 
+logger = logging.getLogger('reprounzip')
+
+
 THIS_DISTRIBUTION = platform.linux_distribution()[0].lower()
 
 

--- a/reprounzip/reprounzip/unpackers/common/packages.py
+++ b/reprounzip/reprounzip/unpackers/common/packages.py
@@ -51,7 +51,7 @@ class AptInstaller(object):
                 required_pkgs.discard(pkg.name)
         if required_pkgs:
             logger.error("Error: some packages could not be installed:%s",
-                          ''.join("\n    %s" % pkg for pkg in required_pkgs))
+                         ''.join("\n    %s" % pkg for pkg in required_pkgs))
 
         return r, pkgs_status
 
@@ -105,8 +105,8 @@ def select_installer(pack, runs, target_distribution=THIS_DISTRIBUTION,
             set(['ubuntu', 'debian'])):
         # Packages are more or less the same on Debian and Ubuntu
         logger.warning("Installing on %s but pack was generated on %s",
-                        target_distribution.capitalize(),
-                        orig_distribution.capitalize())
+                       target_distribution.capitalize(),
+                       orig_distribution.capitalize())
     elif target_distribution is None:
         raise CantFindInstaller("Target distribution is unknown; try using "
                                 "--distribution")

--- a/reprounzip/reprounzip/unpackers/common/packages.py
+++ b/reprounzip/reprounzip/unpackers/common/packages.py
@@ -50,7 +50,7 @@ class AptInstaller(object):
             if status is not None:
                 required_pkgs.discard(pkg.name)
         if required_pkgs:
-            logging.error("Error: some packages could not be installed:%s",
+            logger.error("Error: some packages could not be installed:%s",
                           ''.join("\n    %s" % pkg for pkg in required_pkgs))
 
         return r, pkgs_status
@@ -104,7 +104,7 @@ def select_installer(pack, runs, target_distribution=THIS_DISTRIBUTION,
     elif (set([orig_distribution, target_distribution]) ==
             set(['ubuntu', 'debian'])):
         # Packages are more or less the same on Debian and Ubuntu
-        logging.warning("Installing on %s but pack was generated on %s",
+        logger.warning("Installing on %s but pack was generated on %s",
                         target_distribution.capitalize(),
                         orig_distribution.capitalize())
     elif target_distribution is None:

--- a/reprounzip/reprounzip/unpackers/common/x11.py
+++ b/reprounzip/reprounzip/unpackers/common/x11.py
@@ -116,9 +116,9 @@ class X11Handler(object):
 
         self.xauth = PosixPath('/.reprounzip_xauthority')
         self.display = display if display is not None else self.DISPLAY_NUMBER
-        logger.debug("X11 support enabled; will create Xauthority file %s "
-                      "for experiment. Display number is %d", self.xauth,
-                      self.display)
+        logger.debug("X11 support enabled; will create Xauthority file %s for "
+                     "experiment. Display number is %d", self.xauth,
+                     self.display)
 
         # List of addresses that match the $DISPLAY variable
         possible, local_display = self._locate_display()
@@ -168,8 +168,8 @@ class X11Handler(object):
                 self.connection_info = (socket.AF_UNIX, socket.SOCK_STREAM,
                                         address)
                 self.xauth_record = xauth_entries[(family, None)]
-                logger.debug("Will connect to local X display via UNIX "
-                              "socket %s", address)
+                logger.debug("Will connect to local X display via UNIX socket "
+                             "%s", address)
                 break
             else:
                 # Checks that we have a cookie
@@ -178,8 +178,8 @@ class X11Handler(object):
                                         (address, tcp_portnum))
                 self.xauth_record = xauth_entries[(family, address)]
                 logger.debug("Will connect to X display %s:%d via %s/TCP",
-                              address, tcp_portnum,
-                              "IPv6" if family == socket.AF_INET6 else "IPv4")
+                             address, tcp_portnum,
+                             "IPv6" if family == socket.AF_INET6 else "IPv4")
                 break
 
         # Didn't find an Xauthority record -- assume no authentication is
@@ -193,14 +193,14 @@ class X11Handler(object):
                     self.connection_info = (socket.AF_UNIX, socket.SOCK_STREAM,
                                             address)
                     logger.debug("Will connect to X display via UNIX socket "
-                                  "%s, no authentication", address)
+                                 "%s, no authentication", address)
                     break
             else:
                 self.connection_info = (socket.AF_INET, socket.SOCK_STREAM,
                                         ('127.0.0.1', tcp_portnum))
                 logger.debug("Will connect to X display 127.0.0.1:%d via "
-                              "IPv4/TCP, no authentication",
-                              tcp_portnum)
+                             "IPv4/TCP, no authentication",
+                             tcp_portnum)
 
         if self.connection_info is None:
             raise RuntimeError("Couldn't determine how to connect to local X "
@@ -276,7 +276,7 @@ class X11Handler(object):
         def connect(src_addr):
             logger.info("Got remote X connection from %s", (src_addr,))
             logger.debug("Connecting to X server: %s",
-                          (self.connection_info,))
+                         (self.connection_info,))
             sock = socket.socket(*self.connection_info[:2])
             sock.connect(self.connection_info[2])
             yield sock

--- a/reprounzip/reprounzip/unpackers/common/x11.py
+++ b/reprounzip/reprounzip/unpackers/common/x11.py
@@ -19,6 +19,9 @@ import threading
 from reprounzip.utils import irange, iteritems
 
 
+logger = logging.getLogger('reprounzip')
+
+
 # #include <X11/Xauth.h>
 #
 # typedef struct xauth {

--- a/reprounzip/reprounzip/unpackers/common/x11.py
+++ b/reprounzip/reprounzip/unpackers/common/x11.py
@@ -116,7 +116,7 @@ class X11Handler(object):
 
         self.xauth = PosixPath('/.reprounzip_xauthority')
         self.display = display if display is not None else self.DISPLAY_NUMBER
-        logging.debug("X11 support enabled; will create Xauthority file %s "
+        logger.debug("X11 support enabled; will create Xauthority file %s "
                       "for experiment. Display number is %d", self.xauth,
                       self.display)
 
@@ -151,7 +151,7 @@ class X11Handler(object):
                                            entry.address)] = entry
         # FIXME: this completely ignores addresses
 
-        logging.debug("Possible X endpoints: %s", (possible,))
+        logger.debug("Possible X endpoints: %s", (possible,))
 
         # Select socket and authentication cookie
         self.xauth_record = None
@@ -168,7 +168,7 @@ class X11Handler(object):
                 self.connection_info = (socket.AF_UNIX, socket.SOCK_STREAM,
                                         address)
                 self.xauth_record = xauth_entries[(family, None)]
-                logging.debug("Will connect to local X display via UNIX "
+                logger.debug("Will connect to local X display via UNIX "
                               "socket %s", address)
                 break
             else:
@@ -177,7 +177,7 @@ class X11Handler(object):
                 self.connection_info = (family, socket.SOCK_STREAM,
                                         (address, tcp_portnum))
                 self.xauth_record = xauth_entries[(family, address)]
-                logging.debug("Will connect to X display %s:%d via %s/TCP",
+                logger.debug("Will connect to X display %s:%d via %s/TCP",
                               address, tcp_portnum,
                               "IPv6" if family == socket.AF_INET6 else "IPv4")
                 break
@@ -192,13 +192,13 @@ class X11Handler(object):
                         continue
                     self.connection_info = (socket.AF_UNIX, socket.SOCK_STREAM,
                                             address)
-                    logging.debug("Will connect to X display via UNIX socket "
+                    logger.debug("Will connect to X display via UNIX socket "
                                   "%s, no authentication", address)
                     break
             else:
                 self.connection_info = (socket.AF_INET, socket.SOCK_STREAM,
                                         ('127.0.0.1', tcp_portnum))
-                logging.debug("Will connect to X display 127.0.0.1:%d via "
+                logger.debug("Will connect to X display 127.0.0.1:%d via "
                               "IPv4/TCP, no authentication",
                               tcp_portnum)
 
@@ -237,7 +237,7 @@ class X11Handler(object):
                 continue
             local_addresses.append((family, sockaddr[0]))
 
-        logging.debug("Local addresses: %s", (local_addresses,))
+        logger.debug("Local addresses: %s", (local_addresses,))
 
         # Determine possible addresses for $DISPLAY
         if not local_addr:
@@ -274,14 +274,14 @@ class X11Handler(object):
 
         @contextlib.contextmanager
         def connect(src_addr):
-            logging.info("Got remote X connection from %s", (src_addr,))
-            logging.debug("Connecting to X server: %s",
+            logger.info("Got remote X connection from %s", (src_addr,))
+            logger.debug("Connecting to X server: %s",
                           (self.connection_info,))
             sock = socket.socket(*self.connection_info[:2])
             sock.connect(self.connection_info[2])
             yield sock
             sock.close()
-            logging.info("X connection from %s closed", (src_addr,))
+            logger.info("X connection from %s closed", (src_addr,))
 
         return [(6000 + self.display, connect)]
 

--- a/reprounzip/reprounzip/unpackers/default.py
+++ b/reprounzip/reprounzip/unpackers/default.py
@@ -88,8 +88,8 @@ def installpkgs(args):
             if real == PKG_NOT_INSTALLED:
                 logger.warning("package %s was not installed", pkg.name)
             else:
-                logger.warning("version %s of %s was installed, instead of "
-                                "%s", real, pkg.name, req)
+                logger.warning("version %s of %s was installed, instead of %s",
+                               real, pkg.name, req)
         if r != 0:
             sys.exit(r)
 
@@ -145,7 +145,7 @@ def directory_create(args):
     if missing_files:
         record_usage(directory_missing_pkgs=True)
         logger.error("Some packages are missing, you should probably install "
-                      "them.\nUse 'reprounzip installpkgs -h' for help")
+                     "them.\nUse 'reprounzip installpkgs -h' for help")
 
     root.mkdir()
     try:
@@ -266,7 +266,7 @@ def directory_run(args):
                         rewritten = True
             if rewritten:
                 logger.warning("Rewrote command-line as: %s",
-                                ' '.join(shell_escape(a) for a in argv))
+                               ' '.join(shell_escape(a) for a in argv))
         else:
             argv = cmdline
         cmd += ' '.join(shell_escape(a) for a in argv)
@@ -303,12 +303,12 @@ def should_restore_owner(param):
         if param is True:
             # Restoring the owner was explicitely requested
             logger.critical("Not running as root, cannot restore files' "
-                             "owner/group as requested")
+                            "owner/group as requested")
             sys.exit(1)
         elif param is None:
             # Nothing was requested
             logger.warning("Not running as root, won't restore files' "
-                            "owner/group")
+                           "owner/group")
             ret = False
         else:
             # If False: skip warning
@@ -316,8 +316,7 @@ def should_restore_owner(param):
     else:
         if param is None:
             # Nothing was requested
-            logger.info("Running as root, we will restore files' "
-                         "owner/group")
+            logger.info("Running as root, we will restore files' owner/group")
             ret = True
         elif param is True:
             ret = True
@@ -334,8 +333,7 @@ def should_mount_magic_dirs(param):
     if os.getuid() != 0:
         if param is True:
             # Restoring the owner was explicitely requested
-            logger.critical("Not running as root, cannot mount /dev and "
-                             "/proc")
+            logger.critical("Not running as root, cannot mount /dev and /proc")
             sys.exit(1)
         elif param is None:
             # Nothing was requested
@@ -404,10 +402,10 @@ def chroot_create(args):
         if packages_not_packed:
             record_usage(chroot_missing_pkgs=True)
             logger.warning("According to configuration, some files were left "
-                            "out because they belong to the following "
-                            "packages:%s\nWill copy files from HOST SYSTEM",
-                            ''.join('\n    %s' % pkg
-                                    for pkg in packages_not_packed))
+                           "out because they belong to the following "
+                           "packages:%s\nWill copy files from HOST SYSTEM",
+                           ''.join('\n    %s' % pkg
+                                   for pkg in packages_not_packed))
             missing_files = False
             for pkg in packages_not_packed:
                 for f in pkg.files:
@@ -503,8 +501,8 @@ def chroot_mount(args):
     metadata_write(target, unpacked_info, 'chroot')
 
     logger.warning("The host's /dev and /proc have been mounted into the "
-                    "chroot. Do NOT remove the unpacked directory with "
-                    "rm -rf, it WILL WIPE the host's /dev directory.")
+                   "chroot. Do NOT remove the unpacked directory with rm -rf, "
+                   "it WILL WIPE the host's /dev directory.")
 
 
 @target_must_exist
@@ -703,7 +701,7 @@ class LocalDownloader(FileDownloader):
         # Output to stdout
         if not remote_path.exists():
             logger.critical("Can't get output file (doesn't exist): %s",
-                             remote_path)
+                            remote_path)
             return False
         with remote_path.open('rb') as fp:
             copyfile(fp, stdout_bytes)
@@ -715,7 +713,7 @@ class LocalDownloader(FileDownloader):
         # Copy
         if not remote_path.exists():
             logger.critical("Can't get output file (doesn't exist): %s",
-                             remote_path)
+                            remote_path)
             return False
         remote_path.copyfile(local_path)
         remote_path.copymode(local_path)

--- a/reprounzip/reprounzip/unpackers/default.py
+++ b/reprounzip/reprounzip/unpackers/default.py
@@ -42,6 +42,9 @@ from reprounzip.utils import unicode_, irange, iteritems, itervalues, \
     download_file
 
 
+logger = logging.getLogger('reprounzip')
+
+
 def installpkgs(args):
     """Installs the necessary packages on the current machine.
     """

--- a/reprounzip/reprounzip/unpackers/graph.py
+++ b/reprounzip/reprounzip/unpackers/graph.py
@@ -242,7 +242,7 @@ def parse_levels(level_pkgs, level_processes, level_other_files):
                       'drop': LVL_PKG_DROP}[level_pkgs]
     except KeyError:
         logger.critical("Unknown level of detail for packages: '%s'",
-                         level_pkgs)
+                        level_pkgs)
         sys.exit(1)
     try:
         level_processes = {'thread': LVL_PROC_THREAD,
@@ -253,7 +253,7 @@ def parse_levels(level_pkgs, level_processes, level_other_files):
                            'runs': LVL_PROC_RUN}[level_processes]
     except KeyError:
         logger.critical("Unknown level of detail for processes: '%s'",
-                         level_processes)
+                        level_processes)
         sys.exit(1)
     if level_other_files.startswith('depth:'):
         file_depth = int(level_other_files[6:])
@@ -269,7 +269,7 @@ def parse_levels(level_pkgs, level_processes, level_other_files):
                              'drop': LVL_OTHER_NO}[level_other_files]
     except KeyError:
         logger.critical("Unknown level of detail for other files: '%s'",
-                         level_other_files)
+                        level_other_files)
         sys.exit(1)
 
     return level_pkgs, level_processes, level_other_files, file_depth
@@ -443,9 +443,9 @@ def generate(target, configfile, database, all_forks=False, graph_format='dot',
     # Reads package ownership from the configuration
     if not configfile.is_file():
         logger.critical("Configuration file does not exist!\n"
-                         "Did you forget to run 'reprozip trace'?\n"
-                         "If not, you might want to use --dir to specify an "
-                         "alternate location.")
+                        "Did you forget to run 'reprozip trace'?\n"
+                        "If not, you might want to use --dir to specify an "
+                        "alternate location.")
         sys.exit(1)
     config = load_config(configfile, canonical=False)
     inputs_outputs = dict((f.path, n)
@@ -458,7 +458,7 @@ def generate(target, configfile, database, all_forks=False, graph_format='dot',
     # Label the runs
     if len(runs) != len(config.runs):
         logger.warning("Configuration file doesn't list the same number of "
-                        "runs we found in the database!")
+                       "runs we found in the database!")
     else:
         for config_run, run in izip(config.runs, runs):
             run.name = config_run['id']

--- a/reprounzip/reprounzip/unpackers/graph.py
+++ b/reprounzip/reprounzip/unpackers/graph.py
@@ -34,6 +34,9 @@ from reprounzip.utils import PY3, izip, iteritems, itervalues, stderr, \
     unicode_, escape, normalize_path
 
 
+logger = logging.getLogger('reprounzip')
+
+
 C_INITIAL = 0   # First process or don't know
 C_FORK = 1      # Might actually be any one of fork, vfork or clone
 C_EXEC = 2      # Replaced image with execve

--- a/reprounzip/reprounzip/unpackers/graph.py
+++ b/reprounzip/reprounzip/unpackers/graph.py
@@ -222,7 +222,7 @@ class Package(object):
 
     def json(self, level_pkgs):
         if level_pkgs == LVL_PKG_PACKAGE:
-            logging.critical("JSON output doesn't support --packages package")
+            logger.critical("JSON output doesn't support --packages package")
             sys.exit(1)
         elif level_pkgs == LVL_PKG_FILE:
             files = sorted(unicode_(f) for f in self.files)
@@ -241,7 +241,7 @@ def parse_levels(level_pkgs, level_processes, level_other_files):
                       'ignore': LVL_PKG_IGNORE,
                       'drop': LVL_PKG_DROP}[level_pkgs]
     except KeyError:
-        logging.critical("Unknown level of detail for packages: '%s'",
+        logger.critical("Unknown level of detail for packages: '%s'",
                          level_pkgs)
         sys.exit(1)
     try:
@@ -252,7 +252,7 @@ def parse_levels(level_pkgs, level_processes, level_other_files):
                            'run': LVL_PROC_RUN,
                            'runs': LVL_PROC_RUN}[level_processes]
     except KeyError:
-        logging.critical("Unknown level of detail for processes: '%s'",
+        logger.critical("Unknown level of detail for processes: '%s'",
                          level_processes)
         sys.exit(1)
     if level_other_files.startswith('depth:'):
@@ -268,7 +268,7 @@ def parse_levels(level_pkgs, level_processes, level_other_files):
                              'none': LVL_OTHER_NO,
                              'drop': LVL_OTHER_NO}[level_other_files]
     except KeyError:
-        logging.critical("Unknown level of detail for other files: '%s'",
+        logger.critical("Unknown level of detail for other files: '%s'",
                          level_other_files)
         sys.exit(1)
 
@@ -339,7 +339,7 @@ def read_events(database, all_forks, has_thread_flag):
         ''')
 
     # Loop on all event lists
-    logging.info("Getting all events from database...")
+    logger.info("Getting all events from database...")
     rows = heapq.merge(((r[2], 'process', r) for r in process_rows),
                        ((r[1], 'open', r) for r in file_rows),
                        ((r[1], 'exec', r) for r in exec_rows))
@@ -348,7 +348,7 @@ def read_events(database, all_forks, has_thread_flag):
     for ts, event_type, data in rows:
         if event_type == 'process':
             r_id, r_parent, r_timestamp, r_thread = data
-            logging.debug("Process %d created (parent %r)", r_id, r_parent)
+            logger.debug("Process %d created (parent %r)", r_id, r_parent)
             if r_parent is not None:
                 parent = processes[r_parent]
                 binary = parent.binary
@@ -372,7 +372,7 @@ def read_events(database, all_forks, has_thread_flag):
         elif event_type == 'open':
             r_name, r_timestamp, r_mode, r_process, r_directory = data
             r_name = normalize_path(r_name)
-            logging.debug("File open: %s, process %d", r_name, r_process)
+            logger.debug("File open: %s, process %d", r_name, r_process)
             if not (r_mode & FILE_WDIR or r_directory):
                 process = processes[r_process]
                 files.add(r_name)
@@ -384,7 +384,7 @@ def read_events(database, all_forks, has_thread_flag):
             argv = tuple(r_argv.split('\0'))
             if not argv[-1]:
                 argv = argv[:-1]
-            logging.debug("File exec: %s, process %d", r_name, r_process)
+            logger.debug("File exec: %s, process %d", r_name, r_process)
             process = processes[r_process]
             binaries.add(r_name)
             # Here we split this process in two "programs", unless the previous
@@ -434,7 +434,7 @@ def generate(target, configfile, database, all_forks=False, graph_format='dot',
         graph_format = {'dot': FORMAT_DOT, 'DOT': FORMAT_DOT,
                         'json': FORMAT_JSON, 'JSON': FORMAT_JSON}[graph_format]
     except KeyError:
-        logging.critical("Unknown output format %r", graph_format)
+        logger.critical("Unknown output format %r", graph_format)
         sys.exit(1)
 
     level_pkgs, level_processes, level_other_files, file_depth = \
@@ -442,7 +442,7 @@ def generate(target, configfile, database, all_forks=False, graph_format='dot',
 
     # Reads package ownership from the configuration
     if not configfile.is_file():
-        logging.critical("Configuration file does not exist!\n"
+        logger.critical("Configuration file does not exist!\n"
                          "Did you forget to run 'reprozip trace'?\n"
                          "If not, you might want to use --dir to specify an "
                          "alternate location.")
@@ -457,7 +457,7 @@ def generate(target, configfile, database, all_forks=False, graph_format='dot',
 
     # Label the runs
     if len(runs) != len(config.runs):
-        logging.warning("Configuration file doesn't list the same number of "
+        logger.warning("Configuration file doesn't list the same number of "
                         "runs we found in the database!")
     else:
         for config_run, run in izip(config.runs, runs):
@@ -472,18 +472,18 @@ def generate(target, configfile, database, all_forks=False, graph_format='dot',
     def filefilter(path):
         pathuni = unicode_(path)
         if any(f(pathuni) for f in ignore):
-            logging.debug("IGN %s", pathuni)
+            logger.debug("IGN %s", pathuni)
             return None
         if not (replace or aggregates):
             return path
         for fi in replace:
             pathuni_ = fi(pathuni)
             if pathuni_ != pathuni:
-                logging.debug("SUB %s -> %s", pathuni, pathuni_)
+                logger.debug("SUB %s -> %s", pathuni, pathuni_)
             pathuni = pathuni_
         for prefix in aggregates or []:
             if pathuni.startswith(prefix):
-                logging.debug("AGG %s -> %s", pathuni, prefix)
+                logger.debug("AGG %s -> %s", pathuni, prefix)
                 pathuni = prefix
                 break
         return PosixPath(pathuni)
@@ -508,7 +508,7 @@ def generate(target, configfile, database, all_forks=False, graph_format='dot',
         packages = []
         other_files = files
     else:
-        logging.info("Organizes packages...")
+        logger.info("Organizes packages...")
         file2package = dict((f.path, pkg)
                             for pkg in config.packages for f in pkg.files)
         packages = {}
@@ -570,7 +570,7 @@ def graph_dot(target, runs, packages, other_files, package_map, edges,
                  'fillcolor=black style=filled];\n')
 
         # Programs
-        logging.info("Writing programs...")
+        logger.info("Writing programs...")
         for run in runs:
             run.dot(fp, level_processes)
 
@@ -580,7 +580,7 @@ def graph_dot(target, runs, packages, other_files, package_map, edges,
 
         # Packages
         if level_pkgs not in (LVL_PKG_IGNORE, LVL_PKG_DROP):
-            logging.info("Writing packages...")
+            logger.info("Writing packages...")
             fp.write('\n    /* system packages */\n')
             for package in sorted(packages, key=lambda pkg: pkg.name):
                 package.dot(fp, level_pkgs)
@@ -588,7 +588,7 @@ def graph_dot(target, runs, packages, other_files, package_map, edges,
         fp.write('\n    /* other files */\n')
 
         # Other files
-        logging.info("Writing other files...")
+        logger.info("Writing other files...")
         for fi in sorted(other_files):
             if fi in inputs_outputs:
                 fp.write('    "%(path)s" [fillcolor="#A3B4E0", '
@@ -601,7 +601,7 @@ def graph_dot(target, runs, packages, other_files, package_map, edges,
         fp.write('\n')
 
         # Edges
-        logging.info("Connecting edges...")
+        logger.info("Connecting edges...")
         done_edges = set()
         for prog, fi, mode, argv in edges:
             endp_prog = prog.dot_endpoint(level_processes)

--- a/reprounzip/reprounzip/utils.py
+++ b/reprounzip/reprounzip/utils.py
@@ -30,6 +30,9 @@ import subprocess
 import sys
 
 
+logger = logging.getLogger(__name__.split('.', 1)[0])
+
+
 class StreamWriter(object):
     def __init__(self, stream):
         writer = codecs.getwriter(locale.getpreferredencoding())

--- a/reprounzip/reprounzip/utils.py
+++ b/reprounzip/reprounzip/utils.py
@@ -436,7 +436,7 @@ def download_file(url, dest, cachename=None, ssl_verify=None):
                 logger.info("Download %s: cache is up to date", cachename)
             else:
                 logger.warning("Download %s: error downloading %s: %s",
-                                cachename, url, e)
+                               cachename, url, e)
             if dest is not None:
                 cache.copy(dest)
                 return dest

--- a/reprounzip/reprounzip/utils.py
+++ b/reprounzip/reprounzip/utils.py
@@ -339,14 +339,14 @@ def make_dir_writable(directory):
             path = path / c
             sb = path.stat()
             if sb.st_uid == uid and not sb.st_mode & 0o100:
-                logging.debug("Temporarily setting u+x on %s", path)
+                logger.debug("Temporarily setting u+x on %s", path)
                 restore_perms.append((path, sb.st_mode))
                 path.chmod(sb.st_mode | 0o700)
 
         # Add u+wx to the target
         sb = directory.stat()
         if sb.st_uid == uid and sb.st_mode & 0o700 != 0o700:
-            logging.debug("Temporarily setting u+wx on %s", directory)
+            logger.debug("Temporarily setting u+wx on %s", directory)
             restore_perms.append((directory, sb.st_mode))
             directory.chmod(sb.st_mode | 0o700)
 
@@ -433,9 +433,9 @@ def download_file(url, dest, cachename=None, ssl_verify=None):
     except requests.RequestException as e:
         if cache.exists():
             if e.response and e.response.status_code == 304:
-                logging.info("Download %s: cache is up to date", cachename)
+                logger.info("Download %s: cache is up to date", cachename)
             else:
-                logging.warning("Download %s: error downloading %s: %s",
+                logger.warning("Download %s: error downloading %s: %s",
                                 cachename, url, e)
             if dest is not None:
                 cache.copy(dest)
@@ -445,7 +445,7 @@ def download_file(url, dest, cachename=None, ssl_verify=None):
         else:
             raise
 
-    logging.info("Download %s: downloading %s", cachename, url)
+    logger.info("Download %s: downloading %s", cachename, url)
     try:
         with cache.open('wb') as f:
             for chunk in response.iter_content(4096):
@@ -457,7 +457,7 @@ def download_file(url, dest, cachename=None, ssl_verify=None):
         except OSError:
             pass
         raise e
-    logging.info("Downloaded %s successfully", cachename)
+    logger.info("Downloaded %s successfully", cachename)
 
     if dest is not None:
         cache.copy(dest)

--- a/reprozip/reprozip/common.py
+++ b/reprozip/reprozip/common.py
@@ -579,10 +579,11 @@ def setup_logging(tag, verbosity):
     handler.setLevel(console_level)
     handler.setFormatter(formatter)
 
-    # Set up logger
-    logger = logging.root
-    logger.setLevel(min_level)
-    logger.addHandler(handler)
+    # Set up loggers
+    loggers = [logging.getLogger('reprozip'), logging.getLogger('reprounzip')]
+    for logger in loggers:
+        logger.setLevel(min_level)
+        logger.addHandler(handler)
 
     # File logger
     dotrpz = Path('~/.reprozip').expand_user()
@@ -599,7 +600,8 @@ def setup_logging(tag, verbosity):
     else:
         filehandler.setFormatter(formatter)
         filehandler.setLevel(file_level)
-        logger.addHandler(filehandler)
+        for logger in loggers:
+            logger.addHandler(filehandler)
 
 
 _usage_report = None

--- a/reprozip/reprozip/common.py
+++ b/reprozip/reprozip/common.py
@@ -39,6 +39,9 @@ from .utils import iteritems, itervalues, unicode_, stderr, UniqueNames, \
     copyfile
 
 
+logger = logging.getLogger(__name__.split('.', 1)[0])
+
+
 FILE_READ = 0x01
 FILE_WRITE = 0x02
 FILE_WDIR = 0x04

--- a/reprozip/reprozip/common.py
+++ b/reprozip/reprozip/common.py
@@ -333,16 +333,16 @@ def load_iofiles(config, runs):
         if name in files:
             if files[name].path != path:
                 old_name, name = name, uniquenames(name)
-                logging.warning("File name appears multiple times: %s\n"
+                logger.warning("File name appears multiple times: %s\n"
                                 "Using name %s instead",
                                 old_name, name)
         else:
             uniquenames.insert(name)
         if path in paths:
             if paths[path] == name:
-                logging.warning("File appears multiple times: %s", name)
+                logger.warning("File appears multiple times: %s", name)
             else:
-                logging.warning("Two files have the same path (but different "
+                logger.warning("Two files have the same path (but different "
                                 "names): %s, %s\nUsing name %s",
                                 name, paths[path], paths[path])
                 name = paths[path]
@@ -387,7 +387,7 @@ def load_config(filename, canonical, File=File, Package=Package):
                                 # Deprecated
                                 'input_files', 'output_files'])
     if unknown_keys:
-        logging.warning("Unrecognized sections in configuration: %s",
+        logger.warning("Unrecognized sections in configuration: %s",
                         ', '.join(unknown_keys))
 
     runs = config.get('runs') or []
@@ -599,7 +599,7 @@ def setup_logging(tag, verbosity):
                                                            maxBytes=400000,
                                                            backupCount=5)
     except (IOError, OSError):
-        logging.warning("Couldn't create log file %s", dotrpz / 'log')
+        logger.warning("Couldn't create log file %s", dotrpz / 'log')
     else:
         filehandler.setFormatter(formatter)
         filehandler.setLevel(file_level)

--- a/reprozip/reprozip/common.py
+++ b/reprozip/reprozip/common.py
@@ -334,8 +334,8 @@ def load_iofiles(config, runs):
             if files[name].path != path:
                 old_name, name = name, uniquenames(name)
                 logger.warning("File name appears multiple times: %s\n"
-                                "Using name %s instead",
-                                old_name, name)
+                               "Using name %s instead",
+                               old_name, name)
         else:
             uniquenames.insert(name)
         if path in paths:
@@ -343,8 +343,8 @@ def load_iofiles(config, runs):
                 logger.warning("File appears multiple times: %s", name)
             else:
                 logger.warning("Two files have the same path (but different "
-                                "names): %s, %s\nUsing name %s",
-                                name, paths[path], paths[path])
+                               "names): %s, %s\nUsing name %s",
+                               name, paths[path], paths[path])
                 name = paths[path]
             files[name].read_runs.update(readers)
             files[name].write_runs.update(writers)
@@ -388,7 +388,7 @@ def load_config(filename, canonical, File=File, Package=Package):
                                 'input_files', 'output_files'])
     if unknown_keys:
         logger.warning("Unrecognized sections in configuration: %s",
-                        ', '.join(unknown_keys))
+                       ', '.join(unknown_keys))
 
     runs = config.get('runs') or []
     packages = read_packages(config.get('packages'), File, Package)

--- a/reprozip/reprozip/main.py
+++ b/reprozip/reprozip/main.py
@@ -154,7 +154,7 @@ def testrun(args):
         else:
             argv = args.cmdline
         logger.debug("Starting tracer, binary=%r, argv=%r",
-                      args.cmdline[0], argv)
+                     args.cmdline[0], argv)
         c = _pytracer.execute(args.cmdline[0], argv, database.path,
                               args.verbosity)
         print("\n\n-----------------------------------------------------------"

--- a/reprozip/reprozip/main.py
+++ b/reprozip/reprozip/main.py
@@ -31,6 +31,9 @@ import reprozip.tracer.trace
 from reprozip.utils import PY3, unicode_, stderr
 
 
+logger = logging.getLogger('reprozip')
+
+
 def shell_escape(s):
     """Given bl"a, returns "bl\\"a".
     """

--- a/reprozip/reprozip/main.py
+++ b/reprozip/reprozip/main.py
@@ -153,7 +153,7 @@ def testrun(args):
             argv = [args.arg0] + args.cmdline[1:]
         else:
             argv = args.cmdline
-        logging.debug("Starting tracer, binary=%r, argv=%r",
+        logger.debug("Starting tracer, binary=%r, argv=%r",
                       args.cmdline[0], argv)
         c = _pytracer.execute(args.cmdline[0], argv, database.path,
                               args.verbosity)
@@ -210,13 +210,13 @@ def pack(args):
     target = Path(args.target)
     if not target.unicodename.lower().endswith('.rpz'):
         target = Path(target.path + b'.rpz')
-        logging.warning("Changing output filename to %s", target.unicodename)
+        logger.warning("Changing output filename to %s", target.unicodename)
     reprozip.pack.pack(target, Path(args.dir), args.identify_packages)
 
 
 def usage_report(args):
     if bool(args.enable) == bool(args.disable):
-        logging.critical("What do you want to do?")
+        logger.critical("What do you want to do?")
         sys.exit(2)
     enable_usage_report(args.enable)
     sys.exit(0)

--- a/reprozip/reprozip/pack.py
+++ b/reprozip/reprozip/pack.py
@@ -37,8 +37,8 @@ def expand_patterns(patterns):
 
     # Finds all matching paths
     for pattern in patterns:
-        if logging.root.isEnabledFor(logging.DEBUG):
-            logging.debug("Expanding pattern %r into %d paths",
+        if logger.isEnabledFor(logging.DEBUG):
+            logger.debug("Expanding pattern %r into %d paths",
                           pattern,
                           len(list(Path('/').recursedir(pattern))))
         for path in Path('/').recursedir(pattern):
@@ -104,7 +104,7 @@ class PackBuilder(object):
             path = path / c
             if path in self.seen:
                 continue
-            logging.debug("%s -> %s", path, data_path(path))
+            logger.debug("%s -> %s", path, data_path(path))
             self.tar.add(str(path), str(data_path(path)), recursive=False)
             self.seen.add(path)
 
@@ -118,13 +118,13 @@ def pack(target, directory, sort_packages):
     """
     if target.exists():
         # Don't overwrite packs...
-        logging.critical("Target file exists!")
+        logger.critical("Target file exists!")
         sys.exit(1)
 
     # Reads configuration
     configfile = directory / 'config.yml'
     if not configfile.is_file():
-        logging.critical("Configuration file does not exist!\n"
+        logger.critical("Configuration file does not exist!\n"
                          "Did you forget to run 'reprozip trace'?\n"
                          "If not, you might want to use --dir to specify an "
                          "alternate location.")
@@ -142,7 +142,7 @@ def pack(target, directory, sort_packages):
     for i, run in enumerate(runs):
         if (any(c not in run_chars for c in run['id']) or
                 all(c in string.digits for c in run['id'])):
-            logging.critical("Illegal run id: %r (run number %d)",
+            logger.critical("Illegal run id: %r (run number %d)",
                              run['id'], i)
             sys.exit(1)
 
@@ -150,7 +150,7 @@ def pack(target, directory, sort_packages):
     packages, other_files = canonicalize_config(
         packages, other_files, additional_patterns, sort_packages)
 
-    logging.info("Creating pack %s...", target)
+    logger.info("Creating pack %s...", target)
     tar = tarfile.open(str(target), 'w:gz')
 
     fd, tmp = Path.tempfile()
@@ -160,25 +160,25 @@ def pack(target, directory, sort_packages):
         # Add the files from the packages
         for pkg in packages:
             if pkg.packfiles:
-                logging.info("Adding files from package %s...", pkg.name)
+                logger.info("Adding files from package %s...", pkg.name)
                 files = []
                 for f in pkg.files:
                     if not Path(f.path).exists():
-                        logging.warning("Missing file %s from package %s",
+                        logger.warning("Missing file %s from package %s",
                                         f.path, pkg.name)
                     else:
                         datatar.add_data(f.path)
                         files.append(f)
                 pkg.files = files
             else:
-                logging.info("NOT adding files from package %s", pkg.name)
+                logger.info("NOT adding files from package %s", pkg.name)
 
         # Add the rest of the files
-        logging.info("Adding other files...")
+        logger.info("Adding other files...")
         files = set()
         for f in other_files:
             if not Path(f.path).exists():
-                logging.warning("Missing file %s", f.path)
+                logger.warning("Missing file %s", f.path)
             else:
                 datatar.add_data(f.path)
                 files.add(f)
@@ -189,7 +189,7 @@ def pack(target, directory, sort_packages):
     finally:
         tmp.remove()
 
-    logging.info("Adding metadata...")
+    logger.info("Adding metadata...")
     # Stores pack version
     fd, manifest = Path.tempfile(prefix='reprozip_', suffix='.txt')
     os.close(fd)
@@ -203,14 +203,14 @@ def pack(target, directory, sort_packages):
     # Stores the original trace
     trace = directory / 'trace.sqlite3'
     if not trace.is_file():
-        logging.critical("trace.sqlite3 is gone! Aborting")
+        logger.critical("trace.sqlite3 is gone! Aborting")
         sys.exit(1)
     tar.add(str(trace), 'METADATA/trace.sqlite3')
 
     # Checks that input files are packed
     for name, f in iteritems(inputs_outputs):
         if f.read_runs and not Path(f.path).exists():
-            logging.warning("File is designated as input (name %s) but is not "
+            logger.warning("File is designated as input (name %s) but is not "
                             "to be packed: %s", name, f.path)
 
     # Generates a unique identifier for the pack (for usage reports purposes)

--- a/reprozip/reprozip/pack.py
+++ b/reprozip/reprozip/pack.py
@@ -28,6 +28,9 @@ from reprozip.tracer.trace import merge_files
 from reprozip.utils import iteritems
 
 
+logger = logging.getLogger('reprozip')
+
+
 def expand_patterns(patterns):
     files = set()
     dirs = set()

--- a/reprozip/reprozip/pack.py
+++ b/reprozip/reprozip/pack.py
@@ -39,8 +39,8 @@ def expand_patterns(patterns):
     for pattern in patterns:
         if logger.isEnabledFor(logging.DEBUG):
             logger.debug("Expanding pattern %r into %d paths",
-                          pattern,
-                          len(list(Path('/').recursedir(pattern))))
+                         pattern,
+                         len(list(Path('/').recursedir(pattern))))
         for path in Path('/').recursedir(pattern):
             if path.is_dir():
                 dirs.add(path)
@@ -125,9 +125,9 @@ def pack(target, directory, sort_packages):
     configfile = directory / 'config.yml'
     if not configfile.is_file():
         logger.critical("Configuration file does not exist!\n"
-                         "Did you forget to run 'reprozip trace'?\n"
-                         "If not, you might want to use --dir to specify an "
-                         "alternate location.")
+                        "Did you forget to run 'reprozip trace'?\n"
+                        "If not, you might want to use --dir to specify an "
+                        "alternate location.")
         sys.exit(1)
     runs, packages, other_files = config = load_config(
         configfile,
@@ -143,7 +143,7 @@ def pack(target, directory, sort_packages):
         if (any(c not in run_chars for c in run['id']) or
                 all(c in string.digits for c in run['id'])):
             logger.critical("Illegal run id: %r (run number %d)",
-                             run['id'], i)
+                            run['id'], i)
             sys.exit(1)
 
     # Canonicalize config (re-sort, expand 'additional_files' patterns)
@@ -165,7 +165,7 @@ def pack(target, directory, sort_packages):
                 for f in pkg.files:
                     if not Path(f.path).exists():
                         logger.warning("Missing file %s from package %s",
-                                        f.path, pkg.name)
+                                       f.path, pkg.name)
                     else:
                         datatar.add_data(f.path)
                         files.append(f)
@@ -211,7 +211,7 @@ def pack(target, directory, sort_packages):
     for name, f in iteritems(inputs_outputs):
         if f.read_runs and not Path(f.path).exists():
             logger.warning("File is designated as input (name %s) but is not "
-                            "to be packed: %s", name, f.path)
+                           "to be packed: %s", name, f.path)
 
     # Generates a unique identifier for the pack (for usage reports purposes)
     pack_id = str(uuid.uuid4())

--- a/reprozip/reprozip/tracer/linux_pkgs.py
+++ b/reprozip/reprozip/tracer/linux_pkgs.py
@@ -24,6 +24,9 @@ from reprozip.common import Package
 from reprozip.utils import listvalues
 
 
+logger = logging.getLogger('reprozip')
+
+
 magic_dirs = ('/dev', '/proc', '/sys')
 system_dirs = ('/bin', '/etc', '/lib', '/sbin', '/usr', '/var')
 

--- a/reprozip/reprozip/tracer/linux_pkgs.py
+++ b/reprozip/reprozip/tracer/linux_pkgs.py
@@ -173,7 +173,7 @@ def identify_packages(files):
 
     begin = time.time()
     manager.search_for_files(files)
-    logging.debug("Assigning files to packages took %f seconds",
+    logger.debug("Assigning files to packages took %f seconds",
                   (time.time() - begin))
 
     return manager.unknown_files, listvalues(manager.packages)

--- a/reprozip/reprozip/tracer/linux_pkgs.py
+++ b/reprozip/reprozip/tracer/linux_pkgs.py
@@ -174,6 +174,6 @@ def identify_packages(files):
     begin = time.time()
     manager.search_for_files(files)
     logger.debug("Assigning files to packages took %f seconds",
-                  (time.time() - begin))
+                 (time.time() - begin))
 
     return manager.unknown_files, listvalues(manager.packages)

--- a/reprozip/reprozip/tracer/trace.py
+++ b/reprozip/reprozip/tracer/trace.py
@@ -212,7 +212,7 @@ def get_files(conn):
         if fi.what == TracedFile.READ_THEN_WRITTEN and
         not any(fi.path.lies_under(m) for m in magic_dirs)]
     if read_then_written_files:
-        logging.warning(
+        logger.warning(
             "Some files were read and then written. We will only pack the "
             "final version of the file; reproducible experiments shouldn't "
             "change their input files:\n%s",
@@ -256,7 +256,7 @@ def trace(binary, argv, directory, append, verbosity=1):
     cwd = Path.cwd()
     if (any(cwd.lies_under(c) for c in magic_dirs + system_dirs) and
             not cwd.lies_under('/usr/local')):
-        logging.warning(
+        logger.warning(
             "You are running this experiment from a system directory! "
             "Autodetection of non-system files will probably not work as "
             "intended")
@@ -264,27 +264,27 @@ def trace(binary, argv, directory, append, verbosity=1):
     # Trace directory
     if not append:
         if directory.exists():
-            logging.info("Removing existing directory %s", directory)
+            logger.info("Removing existing directory %s", directory)
             directory.rmtree()
         directory.mkdir(parents=True)
     else:
         if not directory.exists():
-            logging.warning("--continue was specified but %s does not exist "
+            logger.warning("--continue was specified but %s does not exist "
                             "-- creating", directory)
             directory.mkdir(parents=True)
 
     # Runs the trace
     database = directory / 'trace.sqlite3'
-    logging.info("Running program")
+    logger.info("Running program")
     # Might raise _pytracer.Error
     c = _pytracer.execute(binary, argv, database.path, verbosity)
     if c != 0:
         if c & 0x0100:
-            logging.warning("Program appears to have been terminated by "
+            logger.warning("Program appears to have been terminated by "
                             "signal %d", c & 0xFF)
         else:
-            logging.warning("Program exited with non-zero code %d", c)
-    logging.info("Program completed")
+            logger.warning("Program exited with non-zero code %d", c)
+    logger.info("Program completed")
 
 
 def write_configuration(directory, sort_packages, find_inputs_outputs,

--- a/reprozip/reprozip/tracer/trace.py
+++ b/reprozip/reprozip/tracer/trace.py
@@ -29,6 +29,9 @@ from reprozip.utils import PY3, izip, iteritems, itervalues, listvalues, \
     unicode_, flatten, UniqueNames, hsize, normalize_path, find_all_links
 
 
+logger = logging.getLogger('reprozip')
+
+
 class TracedFile(File):
     """Override of `~reprozip.common.File` that reads stats from filesystem.
 

--- a/reprozip/reprozip/tracer/trace.py
+++ b/reprozip/reprozip/tracer/trace.py
@@ -270,7 +270,7 @@ def trace(binary, argv, directory, append, verbosity=1):
     else:
         if not directory.exists():
             logger.warning("--continue was specified but %s does not exist "
-                            "-- creating", directory)
+                           "-- creating", directory)
             directory.mkdir(parents=True)
 
     # Runs the trace
@@ -280,8 +280,8 @@ def trace(binary, argv, directory, append, verbosity=1):
     c = _pytracer.execute(binary, argv, database.path, verbosity)
     if c != 0:
         if c & 0x0100:
-            logger.warning("Program appears to have been terminated by "
-                            "signal %d", c & 0xFF)
+            logger.warning("Program appears to have been terminated by signal "
+                           "%d", c & 0xFF)
         else:
             logger.warning("Program exited with non-zero code %d", c)
     logger.info("Program completed")

--- a/reprozip/reprozip/utils.py
+++ b/reprozip/reprozip/utils.py
@@ -30,6 +30,9 @@ import subprocess
 import sys
 
 
+logger = logging.getLogger(__name__.split('.', 1)[0])
+
+
 class StreamWriter(object):
     def __init__(self, stream):
         writer = codecs.getwriter(locale.getpreferredencoding())

--- a/reprozip/reprozip/utils.py
+++ b/reprozip/reprozip/utils.py
@@ -436,7 +436,7 @@ def download_file(url, dest, cachename=None, ssl_verify=None):
                 logger.info("Download %s: cache is up to date", cachename)
             else:
                 logger.warning("Download %s: error downloading %s: %s",
-                                cachename, url, e)
+                               cachename, url, e)
             if dest is not None:
                 cache.copy(dest)
                 return dest

--- a/reprozip/reprozip/utils.py
+++ b/reprozip/reprozip/utils.py
@@ -339,14 +339,14 @@ def make_dir_writable(directory):
             path = path / c
             sb = path.stat()
             if sb.st_uid == uid and not sb.st_mode & 0o100:
-                logging.debug("Temporarily setting u+x on %s", path)
+                logger.debug("Temporarily setting u+x on %s", path)
                 restore_perms.append((path, sb.st_mode))
                 path.chmod(sb.st_mode | 0o700)
 
         # Add u+wx to the target
         sb = directory.stat()
         if sb.st_uid == uid and sb.st_mode & 0o700 != 0o700:
-            logging.debug("Temporarily setting u+wx on %s", directory)
+            logger.debug("Temporarily setting u+wx on %s", directory)
             restore_perms.append((directory, sb.st_mode))
             directory.chmod(sb.st_mode | 0o700)
 
@@ -433,9 +433,9 @@ def download_file(url, dest, cachename=None, ssl_verify=None):
     except requests.RequestException as e:
         if cache.exists():
             if e.response and e.response.status_code == 304:
-                logging.info("Download %s: cache is up to date", cachename)
+                logger.info("Download %s: cache is up to date", cachename)
             else:
-                logging.warning("Download %s: error downloading %s: %s",
+                logger.warning("Download %s: error downloading %s: %s",
                                 cachename, url, e)
             if dest is not None:
                 cache.copy(dest)
@@ -445,7 +445,7 @@ def download_file(url, dest, cachename=None, ssl_verify=None):
         else:
             raise
 
-    logging.info("Download %s: downloading %s", cachename, url)
+    logger.info("Download %s: downloading %s", cachename, url)
     try:
         with cache.open('wb') as f:
             for chunk in response.iter_content(4096):
@@ -457,7 +457,7 @@ def download_file(url, dest, cachename=None, ssl_verify=None):
         except OSError:
             pass
         raise e
-    logging.info("Downloaded %s successfully", cachename)
+    logger.info("Downloaded %s successfully", cachename)
 
     if dest is not None:
         cache.copy(dest)

--- a/tests/__main__.py
+++ b/tests/__main__.py
@@ -79,11 +79,11 @@ if __name__ == '__main__':
 
     successful = True
     if unittests:
-        logging.info("Running unit tests")
+        logger.info("Running unit tests")
         prog = Program(argv=['tests'] + args.arg, exit=False)
         successful = prog.result.wasSuccessful()
     if functests:
-        logging.info("Running functional tests")
+        logger.info("Running functional tests")
         functional_tests(args.raise_warnings,
                          args.interactive, args.run_vagrant, args.run_docker)
 

--- a/tests/__main__.py
+++ b/tests/__main__.py
@@ -28,6 +28,9 @@ from reprounzip.signals import SignalWarning    # noqa
 from tests.functional import functional_tests   # noqa
 
 
+logger = logging.getLogger('reprozip.testsuite')
+
+
 class Program(unittest.TestProgram):
     def createTests(self):
         if self.testNames is None:


### PR DESCRIPTION
This stops using Python's `logging.root` to log everything.

Consequence of this is that log output from other libraries (paramiko, requests) won't be shown in the log.

I'm wondering what the best practice is here.