### PR TITLE
Merge traces

### DIFF
--- a/reprounzip/reprounzip/common.py
+++ b/reprounzip/reprounzip/common.py
@@ -150,7 +150,7 @@ class RPZPack(object):
             path = PosixPath(path)
         components = path.components[1:]
         if not components:
-            return path.__class__('/')
+            return path.__class__('')
         return path.__class__(*components)
 
     def open_config(self):

--- a/reprozip/reprozip/common.py
+++ b/reprozip/reprozip/common.py
@@ -150,7 +150,7 @@ class RPZPack(object):
             path = PosixPath(path)
         components = path.components[1:]
         if not components:
-            return path.__class__('/')
+            return path.__class__('')
         return path.__class__(*components)
 
     def open_config(self):

--- a/reprozip/reprozip/main.py
+++ b/reprozip/reprozip/main.py
@@ -28,6 +28,7 @@ from reprozip.common import setup_logging, \
     submit_usage_report, record_usage
 import reprozip.pack
 import reprozip.tracer.trace
+import reprozip.traceutils
 from reprozip.utils import PY3, unicode_, stderr
 
 
@@ -211,6 +212,31 @@ def pack(args):
     reprozip.pack.pack(target, Path(args.dir), args.identify_packages)
 
 
+def combine(args):
+    """combine subcommand.
+
+    Reads in multiple trace databases and combines them into one.
+
+    The runs from the original traces are appended ('run_id' field gets
+    translated to avoid conflicts).
+    """
+    traces = []
+    for tracepath in args.traces:
+        if tracepath == '-':
+            tracepath = Path(args.dir) / 'trace.sqlite3'
+        else:
+            tracepath = Path(tracepath)
+            if tracepath.is_dir():
+                tracepath = tracepath / 'trace.sqlite3'
+        traces.append(tracepath)
+
+    reprozip.traceutils.combine_traces(traces, Path(args.dir))
+    reprozip.tracer.trace.write_configuration(Path(args.dir),
+                                              args.identify_packages,
+                                              args.find_inputs_outputs,
+                                              overwrite=True)
+
+
 def usage_report(args):
     if bool(args.enable) == bool(args.disable):
         logging.critical("What do you want to do?")
@@ -316,6 +342,14 @@ def main():
                              default='experiment.rpz',
                              help="Destination file")
     parser_pack.set_defaults(func=pack)
+
+    # combine command
+    parser_combine = subparsers.add_parser(
+        'combine',
+        help="Combine multiple traces into one (possibly as subsequent runs)")
+    add_options(parser_combine)
+    parser_combine.add_argument('traces', nargs=argparse.ONE_OR_MORE)
+    parser_combine.set_defaults(func=combine)
 
     args = parser.parse_args()
     setup_logging('REPROZIP', args.verbosity)

--- a/reprozip/reprozip/pack.py
+++ b/reprozip/reprozip/pack.py
@@ -24,7 +24,7 @@ from reprozip import __version__ as reprozip_version
 from reprozip.common import File, load_config, save_config, \
     record_usage_package
 from reprozip.tracer.linux_pkgs import identify_packages
-from reprozip.tracer.trace import merge_files
+from reprozip.traceutils import merge_files
 from reprozip.utils import iteritems
 
 

--- a/reprozip/reprozip/pack.py
+++ b/reprozip/reprozip/pack.py
@@ -24,7 +24,7 @@ from reprozip import __version__ as reprozip_version
 from reprozip.common import File, load_config, save_config, \
     record_usage_package
 from reprozip.tracer.linux_pkgs import identify_packages
-from reprozip.traceutils import merge_files
+from reprozip.traceutils import combine_files
 from reprozip.utils import iteritems
 
 
@@ -65,8 +65,8 @@ def canonicalize_config(packages, other_files, additional_patterns,
         add_files, add_packages = identify_packages(add_files)
     else:
         add_packages = []
-    other_files, packages = merge_files(add_files, add_packages,
-                                        other_files, packages)
+    other_files, packages = combine_files(add_files, add_packages,
+                                          other_files, packages)
     return packages, other_files
 
 

--- a/reprozip/reprozip/tracer/trace.py
+++ b/reprozip/reprozip/tracer/trace.py
@@ -25,7 +25,7 @@ from reprozip.common import File, InputOutputFile, load_config, save_config, \
     FILE_READ, FILE_WRITE, FILE_LINK
 from reprozip.tracer.linux_pkgs import magic_dirs, system_dirs, \
     identify_packages
-from reprozip.utils import PY3, izip, iteritems, itervalues, listvalues, \
+from reprozip.utils import PY3, izip, iteritems, itervalues, \
     unicode_, flatten, UniqueNames, hsize, normalize_path, find_all_links
 
 
@@ -223,30 +223,6 @@ def get_files(conn):
         if fi.what != TracedFile.WRITTEN and not any(fi.path.lies_under(m)
                                                      for m in magic_dirs))
     return files, inputs, outputs
-
-
-def merge_files(newfiles, newpackages, oldfiles, oldpackages):
-    """Merges two sets of packages and files.
-    """
-    files = set(oldfiles)
-    files.update(newfiles)
-
-    packages = dict((pkg.name, pkg) for pkg in newpackages)
-    for oldpkg in oldpackages:
-        if oldpkg.name in packages:
-            pkg = packages[oldpkg.name]
-            # Here we build TracedFiles from the Files so that the comment
-            # (size, etc) gets set
-            s = set(TracedFile(fi.path) for fi in oldpkg.files)
-            s.update(pkg.files)
-            oldpkg.files = list(s)
-            packages[oldpkg.name] = oldpkg
-        else:
-            oldpkg.files = [TracedFile(fi.path) for fi in oldpkg.files]
-            packages[oldpkg.name] = oldpkg
-    packages = listvalues(packages)
-
-    return files, packages
 
 
 def trace(binary, argv, directory, append, verbosity=1):

--- a/reprozip/reprozip/traceutils.py
+++ b/reprozip/reprozip/traceutils.py
@@ -8,11 +8,67 @@ These are operations on traces that are not directly related to the tracing
 process itself.
 """
 
+import logging
+import os
+from rpaths import Path
+import sqlite3
+
 from reprozip.tracer.trace import TracedFile
-from reprozip.utils import listvalues
+from reprozip.utils import PY3, listvalues
 
 
-def merge_files(newfiles, newpackages, oldfiles, oldpackages):
+def create_schema(conn):
+    """Create the trace database schema on a given SQLite3 connection.
+    """
+    sql = [
+        '''
+        CREATE TABLE processes(
+            id INTEGER NOT NULL PRIMARY KEY,
+            run_id INTEGER NOT NULL,
+            parent INTEGER,
+            timestamp INTEGER NOT NULL,
+            is_thread BOOLEAN NOT NULL,
+            exitcode INTEGER
+            );
+        ''',
+        '''
+        CREATE INDEX proc_parent_idx ON processes(parent);
+        ''',
+        '''
+        CREATE TABLE opened_files(
+            id INTEGER NOT NULL PRIMARY KEY,
+            run_id INTEGER NOT NULL,
+            name TEXT NOT NULL,
+            timestamp INTEGER NOT NULL,
+            mode INTEGER NOT NULL,
+            is_directory BOOLEAN NOT NULL,
+            process INTEGER NOT NULL
+            );
+        ''',
+        '''
+        CREATE INDEX open_proc_idx ON opened_files(process);
+        ''',
+        '''
+        CREATE TABLE executed_files(
+            id INTEGER NOT NULL PRIMARY KEY,
+            name TEXT NOT NULL,
+            run_id INTEGER NOT NULL,
+            timestamp INTEGER NOT NULL,
+            process INTEGER NOT NULL,
+            argv TEXT NOT NULL,
+            envp TEXT NOT NULL,
+            workingdir TEXT NOT NULL
+            );
+        ''',
+        '''
+        CREATE INDEX exec_proc_idx ON executed_files(process);
+        ''',
+    ]
+    for stmt in sql:
+        conn.execute(stmt)
+
+
+def combine_files(newfiles, newpackages, oldfiles, oldpackages):
     """Merges two sets of packages and files.
     """
     files = set(oldfiles)
@@ -34,3 +90,154 @@ def merge_files(newfiles, newpackages, oldfiles, oldpackages):
     packages = listvalues(packages)
 
     return files, packages
+
+
+def combine_traces(traces, target):
+    """Combines multiple trace databases into one.
+
+    The runs from the original traces are appended ('run_id' field gets
+    translated to avoid conflicts).
+
+    :param traces: List of trace database filenames.
+    :type traces: [Path]
+    :param target: Directory where to write the new database and associated
+        configuration file.
+    :type target: Path
+    """
+    # We are probably overwriting on of the traces we're reading, so write to
+    # a temporary file first then move it
+    fd, output = Path.tempfile('.sqlite3', 'reprozip_combined_')
+    if PY3:
+        # On PY3, connect() only accepts unicode
+        conn = sqlite3.connect(str(output))
+    else:
+        conn = sqlite3.connect(output.path)
+    os.close(fd)
+    conn.row_factory = sqlite3.Row
+
+    # Create the schema
+    create_schema(conn)
+
+    # Temporary database with lookup tables
+    conn.execute(
+        '''
+        ATTACH DATABASE '' AS maps;
+        ''')
+    conn.execute(
+        '''
+        CREATE TABLE maps.map_runs(
+            old INTEGER NOT NULL,
+            new INTEGER NOT NULL PRIMARY KEY AUTOINCREMENT
+            );
+        ''')
+    conn.execute(
+        '''
+        CREATE TABLE maps.map_processes(
+            old INTEGER NOT NULL,
+            new INTEGER NOT NULL PRIMARY KEY AUTOINCREMENT
+            );
+        ''')
+
+    # Do the merge
+    for i, other in enumerate(traces):
+        logging.info("Attaching database %s", other)
+
+        # Attach the other trace
+        conn.execute(
+            '''
+            ATTACH DATABASE ? AS trace;
+            ''',
+            (str(other),))
+
+        # Add runs to lookup table
+        conn.execute(
+            '''
+            INSERT INTO maps.map_runs(old)
+            SELECT DISTINCT run_id AS old
+            FROM trace.processes;
+            ''')
+
+        logging.info(
+            "%d rows in maps.map_runs",
+            list(conn.execute('SELECT COUNT(*) FROM maps.map_runs;'))[0][0])
+
+        # Add processes to lookup table
+        conn.execute(
+            '''
+            INSERT INTO maps.map_processes(old)
+            SELECT id AS old
+            FROM trace.processes;
+            ''')
+
+        logging.info(
+            "%d rows in maps.map_processes",
+            list(conn.execute('SELECT COUNT(*) FROM maps.map_processes;'))
+            [0][0])
+
+        # processes
+        logging.info("Insert processes...")
+        conn.execute(
+            '''
+            INSERT INTO processes(id, run_id, parent,
+                                       timestamp, is_thread, exitcode)
+            SELECT p.new AS id, r.new AS run_id, parent,
+                   timestamp, is_thread, exitcode
+            FROM trace.processes t
+            INNER JOIN maps.map_runs r ON t.run_id = r.old
+            INNER JOIN maps.map_processes p ON t.id = p.old;
+            ''')
+
+        # opened_files
+        logging.info("Insert opened_files...")
+        conn.execute(
+            '''
+            INSERT INTO opened_files(run_id, name, timestamp,
+                                     mode, is_directory, process)
+            SELECT r.new AS run_id, name, timestamp,
+                   mode, is_directory, p.new AS process
+            FROM trace.opened_files t
+            INNER JOIN maps.map_runs r ON t.run_id = r.old
+            INNER JOIN maps.map_processes p ON t.process = p.old;
+            ''')
+
+        # executed_files
+        logging.info("Insert executed_files...")
+        conn.execute(
+            '''
+            INSERT INTO executed_files(name, run_id, timestamp, process,
+                                       argv, envp, workingdir)
+            SELECT name, r.new AS run_id, timestamp, p.new AS process,
+                   argv, envp, workingdir
+            FROM trace.executed_files t
+            INNER JOIN maps.map_runs r ON t.run_id = r.old
+            INNER JOIN maps.map_processes p ON t.process = p.old;
+            ''')
+
+        # Flush maps
+        conn.execute(
+            '''
+            DELETE FROM maps.map_runs;
+            ''')
+        conn.execute(
+            '''
+            DELETE FROM maps.map_processes;
+            ''')
+
+        # Detach
+        conn.execute(
+            '''
+            DETACH DATABASE trace;
+            ''')
+
+    conn.execute(
+        '''
+        DETACH DATABASE maps;
+        ''')
+
+    conn.commit()
+    conn.close()
+
+    # Move database to final destination
+    if not target.exists():
+        target.mkdir()
+    output.move(target / 'trace.sqlite3')

--- a/reprozip/reprozip/traceutils.py
+++ b/reprozip/reprozip/traceutils.py
@@ -184,7 +184,8 @@ def combine_traces(traces, target):
                    timestamp, is_thread, exitcode
             FROM trace.processes t
             INNER JOIN maps.map_runs r ON t.run_id = r.old
-            INNER JOIN maps.map_processes p ON t.id = p.old;
+            INNER JOIN maps.map_processes p ON t.id = p.old
+            ORDER BY t.id;
             ''')
 
         # opened_files
@@ -197,7 +198,8 @@ def combine_traces(traces, target):
                    mode, is_directory, p.new AS process
             FROM trace.opened_files t
             INNER JOIN maps.map_runs r ON t.run_id = r.old
-            INNER JOIN maps.map_processes p ON t.process = p.old;
+            INNER JOIN maps.map_processes p ON t.process = p.old
+            ORDER BY t.id;
             ''')
 
         # executed_files
@@ -210,7 +212,8 @@ def combine_traces(traces, target):
                    argv, envp, workingdir
             FROM trace.executed_files t
             INNER JOIN maps.map_runs r ON t.run_id = r.old
-            INNER JOIN maps.map_processes p ON t.process = p.old;
+            INNER JOIN maps.map_processes p ON t.process = p.old
+            ORDER BY t.id;
             ''')
 
         # Flush maps

--- a/reprozip/reprozip/traceutils.py
+++ b/reprozip/reprozip/traceutils.py
@@ -1,0 +1,36 @@
+# Copyright (C) 2014-2016 New York University
+# This file is part of ReproZip which is released under the Revised BSD License
+# See file LICENSE for full license details.
+
+"""Additional manipulations for traces.
+
+These are operations on traces that are not directly related to the tracing
+process itself.
+"""
+
+from reprozip.tracer.trace import TracedFile
+from reprozip.utils import listvalues
+
+
+def merge_files(newfiles, newpackages, oldfiles, oldpackages):
+    """Merges two sets of packages and files.
+    """
+    files = set(oldfiles)
+    files.update(newfiles)
+
+    packages = dict((pkg.name, pkg) for pkg in newpackages)
+    for oldpkg in oldpackages:
+        if oldpkg.name in packages:
+            pkg = packages[oldpkg.name]
+            # Here we build TracedFiles from the Files so that the comment
+            # (size, etc) gets set
+            s = set(TracedFile(fi.path) for fi in oldpkg.files)
+            s.update(pkg.files)
+            oldpkg.files = list(s)
+            packages[oldpkg.name] = oldpkg
+        else:
+            oldpkg.files = [TracedFile(fi.path) for fi in oldpkg.files]
+            packages[oldpkg.name] = oldpkg
+    packages = listvalues(packages)
+
+    return files, packages

--- a/reprozip/reprozip/traceutils.py
+++ b/reprozip/reprozip/traceutils.py
@@ -154,7 +154,8 @@ def combine_traces(traces, target):
             '''
             INSERT INTO maps.map_runs(old)
             SELECT DISTINCT run_id AS old
-            FROM trace.processes;
+            FROM trace.processes
+            ORDER BY run_id;
             ''')
 
         logging.info(
@@ -166,7 +167,8 @@ def combine_traces(traces, target):
             '''
             INSERT INTO maps.map_processes(old)
             SELECT id AS old
-            FROM trace.processes;
+            FROM trace.processes
+            ORDER BY id;
             ''')
 
         logging.info(

--- a/scripts/test_bug_13676.py
+++ b/scripts/test_bug_13676.py
@@ -12,19 +12,19 @@ if __name__ == '__main__':
     conn.row_factory = sqlite3.Row
 
     conn.execute(
-            '''
-            CREATE TABLE test(data TEXT);
-            ''')
+        '''
+        CREATE TABLE test(data TEXT);
+        ''')
     conn.execute(
-            '''
-            INSERT INTO test(data)
-            VALUES(?);
-            ''',
-            (data_in,))
+        '''
+        INSERT INTO test(data)
+        VALUES(?);
+        ''',
+        (data_in,))
     data_rows = conn.execute(
-            '''
-            SELECT data FROM test;
-            ''')
+        '''
+        SELECT data FROM test;
+        ''')
     data_out = next(iter(data_rows))[0]
 
     if data_out == data_in:

--- a/scripts/test_bug_23058.py
+++ b/scripts/test_bug_23058.py
@@ -27,7 +27,7 @@ class Test23058(unittest.TestCase):
         self.do_test_verbosity(parser, 'command -v', 2)
         self.do_test_verbosity(parser, 'command -v -v', 3)
         self.do_test_verbosity(parser, '-v command', 2)  # FAILS
-                # arguments passed to main parser are *silently ignored*
+            # arguments passed to main parser are *silently ignored*
         self.do_test_verbosity(parser, '-v -v command', 3)
         self.do_test_verbosity(parser, '-v -v command -v -v', 5)
 
@@ -48,7 +48,7 @@ class Test23058(unittest.TestCase):
         self.do_test_verbosity(parser, 'command -v', 2)
         self.do_test_verbosity(parser, 'command -v -v', 3)
         self.do_test_verbosity(parser, '-v command', 2)  # FAILS
-                # arguments passed to main parser are *silently ignored*
+            # arguments passed to main parser are *silently ignored*
         self.do_test_verbosity(parser, '-v -v command', 3)
         self.do_test_verbosity(parser, '-v -v command -v -v', 5)
 


### PR DESCRIPTION
Fix #159

Adds a new `reprozip combine` command that reads in multiple trace databases and merges them into one (with all the combined runs).