### PR TITLE
Remove restrictions on download

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,13 @@
 Changelog
 =========
 
+1.0.6 (???)
+-----------
+
+Enhancements:
+* `docker run` gets a `--detach` command, to keep the container running (useful for starting servers on remote machines)
+* Restrictions on upload and download commands have been relaxed, in particular it is possible to download input files as well as output files
+
 1.0.5 (2016-04-07)
 ------------------
 

--- a/docs/faq.rst
+++ b/docs/faq.rst
@@ -9,7 +9,7 @@ Can ReproZip pack a client-server scenario?
 Yes! However, note that only tracing the client will not capture the full story: reproducibility is better achieved (and guaranteed) if the server is traced as well.
 Having said that, currently, ReproZip can only trace local servers: if the server is remote (i.e., running in another machine), ReproZip cannot capture it. In this case, you can trace the client, and the experiment can only be reproduced if the remote server is still running at the moment of the reproduction.
 
-The easiest way to pack a local client-server experiment is to write a script that starts the server, runs your client(s), and then shuts down the server; ReproZip can then trace this script. See :ref:`Further Considerations When Packing <packing-further>` for more information.
+The easiest way to pack a local client-server experiment is to write a script that starts the server, runs your client(s), and then shuts down the server; ReproZip can then trace this script. See :ref:`Capturing Connections to Servers <packing-clientserv>` for more information.
 
 Can ReproZip pack a database?
 =============================

--- a/docs/packing.rst
+++ b/docs/packing.rst
@@ -166,6 +166,8 @@ Packing GUI and Interactive Tools
 
 ReproZip is able to pack GUI tools. Additionally, there is no restriction in packing interactive experiments (i.e., experiments that require input from users). Note, however, that if entering something different can make the experiment load additional dependencies, the experiment will probably fail when reproduced on a different machine.
 
+..  _packing-clientserv:
+
 Capturing Connections to Servers
 ++++++++++++++++++++++++++++++++
 
@@ -176,6 +178,18 @@ When reproducing an experiment that communicates with a server, the experiment w
 * stop the server,
 
 and use *reprozip* to trace the script execution, rather than the experiment itself. In this way, ReproZip is able to capture the local server as well, which ensures that the server will be alive at the time of the reproduction.
+
+For example, to start postgresql, then a webserver (that will run until Ctrl+C is received), then stop postgresql::
+
+    #!/bin/sh
+
+    /etc/init.d/postgresql start    # Start PostgreSQL
+
+    trap ' ' INT                    # Don't exit the whole script on Ctrl+C
+    ./manage.py runserver 0.0.0.0:8000
+    trap - INT
+
+    /etc/init.d/postgresql stop     # Stop PostgreSQL
 
 Excluding Sensitive and Third-Party Information
 +++++++++++++++++++++++++++++++++++++++++++++++

--- a/reprounzip-docker/reprounzip/unpackers/docker.py
+++ b/reprounzip-docker/reprounzip/unpackers/docker.py
@@ -310,7 +310,7 @@ def docker_reset(args):
         write_dict(target, unpacked_info)
 
 
-_addr_re = re.compile(br'^(?:[a-z]+://)?([[0-9a-zA-Z_.-]+)(?::[0-9]+)?$')
+_addr_re = re.compile(r'^(?:[a-z]+://)?([[0-9a-zA-Z_.-]+)(?::[0-9]+)?$')
 
 
 def get_local_addr():

--- a/reprounzip/reprounzip/unpackers/common/misc.py
+++ b/reprounzip/reprounzip/unpackers/common/misc.py
@@ -249,20 +249,20 @@ class FileDownloader(object):
 
     def run(self, files, all_):
         reprounzip.common.record_usage(download_files=len(files))
-        output_files = {n: f.path
-                        for n, f in iteritems(self.get_config().inputs_outputs)
-                        if f.write_runs}
+        inputs_outputs = self.get_config().inputs_outputs
 
         # No argument: list all the output files and exit
         if not (all_ or files):
             print("Output files:")
-            for output_name in output_files:
+            for output_name in sorted(n for n, f in iteritems(inputs_outputs)
+                                      if f.write_runs):
                 print("    %s" % output_name)
             return
 
         # Parse the name[:path] syntax
         resolved_files = []
-        all_files = set(output_files)
+        all_files = set(n for n, f in iteritems(inputs_outputs)
+                        if f.write_runs)
         for filespec in files:
             filespec_split = filespec.split(':', 1)
             if len(filespec_split) == 1:
@@ -289,7 +289,7 @@ class FileDownloader(object):
             # Download files
             for output_name, local_path in resolved_files:
                 try:
-                    remote_path = output_files[output_name]
+                    remote_path = inputs_outputs[output_name].path
                 except KeyError:
                     logging.critical("Invalid output file: %r", output_name)
                     sys.exit(1)

--- a/reprounzip/reprounzip/unpackers/common/misc.py
+++ b/reprounzip/reprounzip/unpackers/common/misc.py
@@ -141,14 +141,13 @@ class FileUploader(object):
 
     def run(self, files):
         reprounzip.common.record_usage(upload_files=len(files))
-        input_files = {n: f.path
-                       for n, f in iteritems(self.get_config().inputs_outputs)
-                       if f.read_runs}
+        inputs_outputs = self.get_config().inputs_outputs
 
         # No argument: list all the input files and exit
         if not files:
             print("Input files:")
-            for input_name in sorted(input_files):
+            for input_name in sorted(n for n, f in iteritems(inputs_outputs)
+                                     if f.read_runs):
                 assigned = self.input_files.get(input_name)
                 if assigned is None:
                     assigned = "(original)"
@@ -174,7 +173,7 @@ class FileUploader(object):
                 local_path, input_name = filespec_split
 
                 try:
-                    input_path = input_files[input_name]
+                    input_path = inputs_outputs[input_name].path
                 except KeyError:
                     logging.critical("Invalid input file: %r", input_name)
                     sys.exit(1)


### PR DESCRIPTION
Previously, it was only possible to download a file that was marked as output (for one of the runs).

Now the user can download any of the files, including those which are only used as input.