### PR TITLE
--continue overhaul

### DIFF
--- a/docs/packing.rst
+++ b/docs/packing.rst
@@ -18,7 +18,7 @@ The following command is used to trace a command line, or a `run`, used by the e
 
 where `<command-line>` is the command line. By running this command, *reprozip* executes `<command-line>` and uses ``ptrace`` to trace all the system calls issued, storing them in an SQLite database.
 
-Multiple runs can also be traced and combined in a single package by using the flag ``--continue``, or ``-c``, for all the runs except the first one::
+If you run the command multiple times, *reprozip* might ask you if you want to continue with your current trace (append the new command-line to it) or replace it (throw away the previous command-line you traced). You can skip this prompt by using either the ``--continue`` or ``--overwrite`` flag, like this::
 
     $ reprozip trace --continue <command-line>
 

--- a/reprozip/reprozip/main.py
+++ b/reprozip/reprozip/main.py
@@ -177,10 +177,19 @@ def trace(args):
         argv = [args.arg0] + args.cmdline[1:]
     else:
         argv = args.cmdline
+    if args.append and args.overwrite:
+        logging.critical("You can't use both --continue and --overwrite")
+        sys.exit(2)
+    elif args.append:
+        append = True
+    elif args.overwrite:
+        append = False
+    else:
+        append = None
     reprozip.tracer.trace.trace(args.cmdline[0],
                                 argv,
                                 Path(args.dir),
-                                args.append,
+                                append,
                                 args.verbosity)
     reprozip.tracer.trace.write_configuration(Path(args.dir),
                                               args.identify_packages,
@@ -309,7 +318,10 @@ def main():
         help="argument 0 to program, if different from program path")
     parser_trace.add_argument(
         '-c', '--continue', action='store_true', dest='append',
-        help="add to the previous run instead of replacing it")
+        help="add to the previous trace, don't replace it")
+    parser_trace.add_argument(
+        '-w', '--overwrite', action='store_true', dest='overwrite',
+        help="overwrite the previous trace, don't add to it")
     parser_trace.add_argument('cmdline', nargs=argparse.REMAINDER,
                               help="command-line to run under trace")
     parser_trace.set_defaults(func=trace)

--- a/reprozip/reprozip/tracer/trace.py
+++ b/reprozip/reprozip/tracer/trace.py
@@ -292,6 +292,9 @@ def trace(binary, argv, directory, append, verbosity=1):
             elif r in 'dD':
                 directory.rmtree()
                 directory.mkdir()
+            logging.warning(
+                "You can use --overwrite to replace the existing trace "
+                "(or --continue to append\nwithout prompt)")
         elif append is False:
             logging.info("Removing existing trace directory %s", directory)
             directory.rmtree()

--- a/reprozip/reprozip/tracer/trace.py
+++ b/reprozip/reprozip/tracer/trace.py
@@ -285,16 +285,19 @@ def trace(binary, argv, directory, append, verbosity=1):
             "intended")
 
     # Trace directory
-    if not append:
-        if directory.exists():
-            logging.warning("Removing existing directory %s", directory)
+    if directory.exists():
+        if append is None:
+            if not tty_prompt_yesno("Trace directory %s exists, append run "
+                                    "to the trace? " % directory):
+                sys.exit(1)
+        elif append is False:
+            logging.info("Removing existing trace directory %s", directory)
             directory.rmtree()
-        directory.mkdir(parents=True)
-    else:
-        if not directory.exists():
-            logging.warning("--continue was specified but %s does not exist "
-                            "-- creating", directory)
             directory.mkdir(parents=True)
+    else:
+        if append is True:
+            logging.warning("--continue was set but trace doesn't exist yet")
+        directory.mkdir()
 
     # Runs the trace
     database = directory / 'trace.sqlite3'

--- a/tests/functional.py
+++ b/tests/functional.py
@@ -136,7 +136,7 @@ def functional_tests(raise_warnings, interactive, run_vagrant, run_docker):
                       'cat ../../../../../etc/passwd;'
                       'cd /var/lib;'
                       'cat ../../etc/group'])
-    check_call(rpz + ['trace',
+    check_call(rpz + ['trace', '--overwrite',
                       'bash', '-c', 'cat /etc/passwd;echo'])
     check_call(rpz + ['trace', '--continue',
                       'sh', '-c', 'cat /etc/group;/usr/bin/id'])
@@ -167,7 +167,7 @@ def functional_tests(raise_warnings, interactive, run_vagrant, run_docker):
     # Build
     build('simple', ['simple.c'])
     # Trace
-    check_call(rpz + ['trace', '-d', 'rpz-simple',
+    check_call(rpz + ['trace', '--overwrite', '-d', 'rpz-simple',
                       './simple',
                       (tests / 'simple_input.txt').path,
                       'simple_output.txt'])
@@ -486,7 +486,8 @@ def functional_tests(raise_warnings, interactive, run_vagrant, run_docker):
     # Build
     build('exec_echo', ['exec_echo.c'])
     # Trace
-    check_call(rpz + ['trace', './exec_echo', 'originalexecechooutput'])
+    check_call(rpz + ['trace', '--overwrite',
+                      './exec_echo', 'originalexecechooutput'])
     # Pack
     check_call(rpz + ['pack', 'exec_echo.rpz'])
     # Unpack chroot
@@ -561,7 +562,8 @@ def functional_tests(raise_warnings, interactive, run_vagrant, run_docker):
     # Build
     build('rename', ['rename.c'])
     # Trace
-    check_call(rpz + ['trace', '-d', 'rename-trace', './rename'])
+    check_call(rpz + ['trace', '--overwrite', '-d', 'rename-trace',
+                      './rename'])
     with Path('rename-trace/config.yml').open(encoding='utf-8') as fp:
         config = yaml.safe_load(fp)
     # Check that written files were logged
@@ -604,8 +606,8 @@ def functional_tests(raise_warnings, interactive, run_vagrant, run_docker):
     Path('e').chmod(0o744)
 
     # Trace
-    out = check_output(rpz + ['trace', '--dont-identify-packages',
-                              '-d', 'shebang-trace', './a', '1', '2'])
+    out = check_output(rpz + ['trace', '--overwrite', '-d', 'shebang-trace',
+                              '--dont-identify-packages', './a', '1', '2'])
     out = out.splitlines()[0]
     assert out == ('e %s 0 ./a 1 2' % (Path.cwd() / 'c')).encode('ascii')
 


### PR DESCRIPTION
Previously, not specifying `--continue` would discard the existing trace, which was dangerous.

Now, a new option `--overwrite` has been added to explicitly request this behavior, and if none of `--continue` or `--overwrite` are specified and a trace exists, reprozip will ask what to do (batch scripts should thus include one of the two in order to run uninterrupted).

    +-------------+------------+--------------+------------------------+
    | --overwrite | --continue | trace exists | action                 |
    +-------------+------------+--------------+------------------------+
    |     Yes     |     Yes    |       *      | error                  |
    |      *      |     No     |      No      | create new trace       |
    |     No      |     Yes    |      No      | create new trace, warn |
    |     No      |     No     |      Yes     | ask: append/abort      |
    |     Yes     |     No     |      Yes     | replace                |
    |     No      |     Yes    |      Yes     | append                 |
    +-------------+------------+--------------+------------------------+