### PR TITLE
Make building the list for TAR faster

### DIFF
--- a/reprounzip-docker/reprounzip/unpackers/docker.py
+++ b/reprounzip-docker/reprounzip/unpackers/docker.py
@@ -215,19 +215,19 @@ def docker_setup_create(args):
             # Add intermediate directories, and check for existence in the tar
             missing_files = chain.from_iterable(pkg.files
                                                 for pkg in missing_packages)
-            for f in chain(other_files, missing_files):
+            data_files = rpz_pack.data_filenames()
+            listoffiles = list(chain(other_files, missing_files))
+            for f in listoffiles:
                 path = PosixPath('/')
                 for c in rpz_pack.remove_data_prefix(f.path).components:
                     path = path / c
                     if path in paths:
                         continue
                     paths.add(path)
-                    try:
-                        rpz_pack.get_data(path)
-                    except KeyError:
-                        logging.info("Missing file %s", path)
-                    else:
+                    if path in data_files:
                         pathlist.append(path)
+                    else:
+                        logging.info("Missing file %s", path)
             rpz_pack.close()
             # FIXME : for some reason we need reversed() here, I'm not sure why
             # Need to read more of tar's docs.

--- a/reprounzip-vagrant/reprounzip/unpackers/vagrant/__init__.py
+++ b/reprounzip-vagrant/reprounzip/unpackers/vagrant/__init__.py
@@ -289,6 +289,7 @@ def vagrant_setup_create(args):
                 pathlist = []
                 # Adds intermediate directories, and checks for existence in
                 # the tar
+                data_files = rpz_pack.data_filenames()
                 for f in other_files:
                     path = PosixPath('/')
                     for c in rpz_pack.remove_data_prefix(f.path).components:
@@ -296,12 +297,10 @@ def vagrant_setup_create(args):
                         if path in paths:
                             continue
                         paths.add(path)
-                        try:
-                            rpz_pack.get_data(path)
-                        except KeyError:
-                            logging.info("Missing file %s", path)
-                        else:
+                        if path in data_files:
                             pathlist.append(path)
+                        else:
+                            logging.info("Missing file %s", path)
                 # FIXME : for some reason we need reversed() here, I'm not sure
                 # why. Need to read more of tar's docs.
                 # TAR bug: --no-overwrite-dir removes --keep-old-files

--- a/reprounzip/reprounzip/common.py
+++ b/reprounzip/reprounzip/common.py
@@ -217,6 +217,16 @@ class RPZPack(object):
                 for m in self.data.getmembers()
                 if m.name.startswith('DATA/')]
 
+    def data_filenames(self):
+        """Returns a set of filenames for all the data paths.
+
+        Those paths begin with a slash / and the 'DATA' prefix has been
+        removed.
+        """
+        return set(PosixPath(m.name[4:])
+                   for m in self.data.getmembers()
+                   if m.name.startswith('DATA/'))
+
     def get_data(self, path):
         """Returns a tarfile.TarInfo object for the data path.
 

--- a/reprozip/reprozip/common.py
+++ b/reprozip/reprozip/common.py
@@ -217,6 +217,16 @@ class RPZPack(object):
                 for m in self.data.getmembers()
                 if m.name.startswith('DATA/')]
 
+    def data_filenames(self):
+        """Returns a set of filenames for all the data paths.
+
+        Those paths begin with a slash / and the 'DATA' prefix has been
+        removed.
+        """
+        return set(PosixPath(m.name[4:])
+                   for m in self.data.getmembers()
+                   if m.name.startswith('DATA/'))
+
     def get_data(self, path):
         """Returns a tarfile.TarInfo object for the data path.
 


### PR DESCRIPTION
The loop building the list of files that is written to `rpz-files.list`, for both Vagrant and Docker, was very slow because the lookups in the data TAR (to check that the files are there) perform a list scan.

We now build a set of all the files in that TAR first and lookup files in that, which is faster in practical situations.