### PR TITLE
File filters for specific situations through plugins

### DIFF
--- a/reprozip/reprozip/filters.py
+++ b/reprozip/reprozip/filters.py
@@ -4,20 +4,24 @@
 
 from __future__ import division, print_function, unicode_literals
 
+import logging
+
 from reprozip.tracer.trace import TracedFile
-from reprozip.utils import iteritems
+from reprozip.utils import irange, iteritems
 
 
-def python(files):
+def python(files, inputs):
     remove = []
     add = []
     for path, fi in iteritems(files):
         if path.ext == '.pyc':
             pyfile = path.parent / path.stem + '.py'
             if pyfile.is_file():
+                logging.info("Removing %s", path)
                 remove.append(path)
                 pyfile = path.parent / path.stem + '.py'
                 if pyfile not in files:
+                    logging.info("Adding %s", pyfile)
                     add.append(TracedFile(pyfile))
 
     for path in remove:
@@ -25,3 +29,13 @@ def python(files):
 
     for fi in add:
         files[fi.path] = fi
+
+    for i in irange(len(inputs)):
+        lst = []
+        for path in inputs[i]:
+            if path.ext in ('.py', '.pyc'):
+                logging.info("Removing input %s", path)
+            else:
+                lst.append(path)
+
+        inputs[i] = lst

--- a/reprozip/reprozip/filters.py
+++ b/reprozip/reprozip/filters.py
@@ -10,7 +10,21 @@ from reprozip.tracer.trace import TracedFile
 from reprozip.utils import irange, iteritems
 
 
-def python(files, inputs):
+def builtin(input_files, **kwargs):
+    """Default heuristics for input files.
+    """
+    for i in irange(len(input_files)):
+        lst = []
+        for path in input_files[i]:
+            if path.unicodename[0] == '.' or path.ext in ('.pyc', '.so'):
+                logging.info("Removing input %s", path)
+            else:
+                lst.append(path)
+
+        input_files[i] = lst
+
+
+def python(files, input_files, **kwargs):
     remove = []
     add = []
     for path, fi in iteritems(files):
@@ -30,12 +44,12 @@ def python(files, inputs):
     for fi in add:
         files[fi.path] = fi
 
-    for i in irange(len(inputs)):
+    for i in irange(len(input_files)):
         lst = []
-        for path in inputs[i]:
+        for path in input_files[i]:
             if path.ext in ('.py', '.pyc'):
                 logging.info("Removing input %s", path)
             else:
                 lst.append(path)
 
-        inputs[i] = lst
+        input_files[i] = lst

--- a/reprozip/reprozip/filters.py
+++ b/reprozip/reprozip/filters.py
@@ -1,0 +1,27 @@
+# Copyright (C) 2014-2016 New York University
+# This file is part of ReproZip which is released under the Revised BSD License
+# See file LICENSE for full license details.
+
+from __future__ import division, print_function, unicode_literals
+
+from reprozip.tracer.trace import TracedFile
+from reprozip.utils import iteritems
+
+
+def python(files):
+    remove = []
+    add = []
+    for path, fi in iteritems(files):
+        if path.ext == '.pyc':
+            pyfile = path.parent / path.stem + '.py'
+            if pyfile.is_file():
+                remove.append(path)
+                pyfile = path.parent / path.stem + '.py'
+                if pyfile not in files:
+                    add.append(TracedFile(pyfile))
+
+    for path in remove:
+        files.pop(path, None)
+
+    for fi in add:
+        files[fi.path] = fi

--- a/reprozip/reprozip/tracer/trace.py
+++ b/reprozip/reprozip/tracer/trace.py
@@ -91,13 +91,13 @@ class TracedFile(File):
                 self.runs[run] = TracedFile.READ_THEN_WRITTEN
 
 
-def run_filter_plugins(files, inputs):
+def run_filter_plugins(files, input_files):
     for entry_point in iter_entry_points('reprozip.filters'):
         func = entry_point.load()
         name = entry_point.name
 
         logging.info("Running filter plugin %s", name)
-        func(files, inputs)
+        func(files=files, input_files=input_files)
 
 
 def get_files(conn):

--- a/reprozip/setup.py
+++ b/reprozip/setup.py
@@ -49,7 +49,8 @@ setup(name='reprozip',
           'console_scripts': [
               'reprozip = reprozip.main:main'],
           'reprozip.filters': [
-              'python = reprozip.filters:python']},
+              'python = reprozip.filters:python',
+              'builtin = reprozip.filters:builtin']},
       install_requires=req,
       description="Linux tool enabling reproducible experiments (packer)",
       author="Remi Rampin, Fernando Chirigati, Dennis Shasha, Juliana Freire",

--- a/reprozip/setup.py
+++ b/reprozip/setup.py
@@ -45,8 +45,11 @@ setup(name='reprozip',
       version='1.0.7',
       ext_modules=[pytracer],
       packages=['reprozip', 'reprozip.tracer'],
-      entry_points={'console_scripts': [
-          'reprozip = reprozip.main:main']},
+      entry_points={
+          'console_scripts': [
+              'reprozip = reprozip.main:main'],
+          'reprozip.filters': [
+              'python = reprozip.filters:python']},
       install_requires=req,
       description="Linux tool enabling reproducible experiments (packer)",
       author="Remi Rampin, Fernando Chirigati, Dennis Shasha, Juliana Freire",


### PR DESCRIPTION
Fix #201

Adds plugins through entry_points to reprozip to go over the list of detected files before writing out the configuration.

This is useful to filter out .pyc files, remove code from input files, ...