### PR TITLE
Don't let experiment override resolv.conf

### DIFF
--- a/reprounzip-docker/reprounzip/unpackers/docker.py
+++ b/reprounzip-docker/reprounzip/unpackers/docker.py
@@ -220,6 +220,11 @@ def docker_setup_create(args):
             data_files = rpz_pack.data_filenames()
             listoffiles = list(chain(other_files, missing_files))
             for f in listoffiles:
+                if f.path.name == 'resolv.conf' and (
+                        f.path.lies_under('/etc') or
+                        f.path.lies_under('/run') or
+                        f.path.lies_under('/var')):
+                    continue
                 path = PosixPath('/')
                 for c in rpz_pack.remove_data_prefix(f.path).components:
                     path = path / c

--- a/reprounzip-vagrant/reprounzip/unpackers/vagrant/__init__.py
+++ b/reprounzip-vagrant/reprounzip/unpackers/vagrant/__init__.py
@@ -318,6 +318,11 @@ def vagrant_setup_create(args):
                 # the tar
                 data_files = rpz_pack.data_filenames()
                 for f in other_files:
+                    if f.path.name == 'resolv.conf' and (
+                            f.path.lies_under('/etc') or
+                            f.path.lies_under('/run') or
+                            f.path.lies_under('/var')):
+                        continue
                     path = PosixPath('/')
                     for c in rpz_pack.remove_data_prefix(f.path).components:
                         path = path / c

--- a/reprounzip-vagrant/reprounzip/unpackers/vagrant/__init__.py
+++ b/reprounzip-vagrant/reprounzip/unpackers/vagrant/__init__.py
@@ -310,6 +310,9 @@ def vagrant_setup_create(args):
                         fp.write('cp -L %s %s\n' % (
                                  shell_escape(unicode_(f)),
                                  shell_escape(unicode_(dest))))
+                fp.write(
+                    '\n'
+                    'cp /etc/resolv.conf /experimentroot/etc/resolv.conf\n')
             else:
                 fp.write('\ncd /\n')
                 paths = set()

--- a/reprounzip/reprounzip/unpackers/default.py
+++ b/reprounzip/reprounzip/unpackers/default.py
@@ -444,6 +444,13 @@ def chroot_create(args):
         rpz_pack.extract_data(root, members)
         rpz_pack.close()
 
+        resolvconf_src = Path('/etc/resolv.conf')
+        if resolvconf_src.exists():
+            try:
+                resolvconf_src.copy(root / 'etc/resolv.conf')
+            except IOError:
+                pass
+
         # Sets up /bin/sh and /usr/bin/env, downloading busybox if necessary
         sh_path = join_root(root, Path('/bin/sh'))
         env_path = join_root(root, Path('/usr/bin/env'))


### PR DESCRIPTION
If an experiment brings its own resolv.conf which lists an unreachable DNS server, the experiment won't be able to connect to the Internet.

* [x] chroot
* [x] reprounzip-vagrant
* [x] reprounzip-docker