### PR TITLE
Docker machine support for the GUI

### DIFF
--- a/reprounzip-docker/reprounzip/unpackers/docker.py
+++ b/reprounzip-docker/reprounzip/unpackers/docker.py
@@ -287,6 +287,17 @@ def docker_setup_build(args):
 
     unpacked_info['initial_image'] = image
     unpacked_info['current_image'] = image
+    if 'DOCKER_MACHINE_NAME' in os.environ:
+        unpacked_info['docker_host'] = {
+            'type': 'docker-machine',
+            'name': os.environ['DOCKER_MACHINE_NAME']}
+    elif 'DOCKER_HOST' in os.environ:
+        unpacked_info['docker_host'] = {
+            'type': 'custom',
+            'env': dict((k, v)
+                        for k, v in iteritems(os.environ)
+                        if k.startswith('DOCKER_'))}
+
     write_dict(target, unpacked_info)
 
 


### PR DESCRIPTION
This adds a drop-down in the options for the Docker unpacker allowing the user to choose one of the defined machines, if he has docker-machine installed.

The core Docker unpacker saves the docker-machine configuration in the unpacked metadata after setup/build, this is only used by the GUI for the run step (core unpacker won't use that).

![screenshot](https://cloud.githubusercontent.com/assets/426784/25203713/3b4191a2-2528-11e7-9c11-aef77d5409e3.png)

* [X] Store info from core docker unpacker
* [X] Show machines in UI
* [X] Get machine configuration
* [x] Use machine to unpack
* [x] Use machine to run