### PR TITLE
Create stand-alone Docker images via entrypoint

### DIFF
--- a/reprounzip-docker/reprounzip/unpackers/docker.py
+++ b/reprounzip-docker/reprounzip/unpackers/docker.py
@@ -33,7 +33,7 @@ from reprounzip.unpackers.common import COMPAT_OK, COMPAT_MAYBE, \
     fixup_environment, interruptible_call, metadata_read, metadata_write, \
     metadata_initial_iofiles, metadata_update_run, parse_ports
 from reprounzip.unpackers.common.x11 import X11Handler, LocalForwarder
-from reprounzip.utils import unicode_, iteritems, stderr, join_root, \
+from reprounzip.utils import unicode_, irange, iteritems, stderr, join_root, \
     download_file
 
 
@@ -249,6 +249,113 @@ def docker_setup_create(args):
                      '--numeric-owner --strip=1 --null -T /rpz-files.list || '
                      '/busybox echo "TAR reports errors, this might or might '
                      'not prevent the execution to run")\n')
+
+            # Setup entry point
+            fp.write('COPY rpz_entrypoint.sh /rpz_entrypoint.sh\n'
+                     'ENTRYPOINT ["/busybox", "sh", "/rpz_entrypoint.sh"]\n')
+
+        # Write entry point script
+        logging.info("Writing %s...", target / 'rpz_entrypoint.sh')
+        with (target / 'rpz_entrypoint.sh').open('w', encoding='utf-8',
+                                                 newline='\n') as fp:
+            # The entrypoint gets some arguments from the run command
+            # By default, it just does all the runs
+            # "run N" executes the run with that number
+            # "cmd STR" sets a replacement command-line for the next run
+            # "do STR" executes a command as-is
+            fp.write(
+                '#!/bin/sh\n'
+                '\n'
+                'COMMAND=\n'
+                'ENVVARS=\n'
+                '\n'
+                'if [ $# = 0 ]; then\n'
+                '    exec /busybox sh /rpz_entrypoint.sh')
+            for nb in irange(len(runs)):
+                fp.write(' run %d' % nb)
+            fp.write(
+                '\n'
+                'fi\n'
+                '\n'
+                'while [ $# != 0 ]; do\n'
+                '    case "$1" in\n'
+                '        help)\n'
+                '            echo "Image built from reprounzip-docker" >&2\n'
+                '            echo "Usage: docker run <image> [cmd word [word '
+                '...]] [run <R>]" >&2\n'
+                '            echo "    \\`cmd ...\\` changes the command for '
+                'the next \\`run\\` option" >&2\n'
+                '            echo "    \\`run <name|number>\\` runs the '
+                'specified run" >&2\n'
+                '            echo "By default, all the runs are executed." '
+                '>&2\n'
+                '            echo "The runs in this image are:" >&2\n')
+            for run in runs:
+                fp.write(
+                    '            echo "    {name}: {cmdline}" >&2\n'.format(
+                        name=run['id'],
+                        cmdline=' '.join(shell_escape(a)
+                                         for a in run['argv'])))
+            fp.write(
+                '            exit 0\n'
+                '        ;;\n'
+                '        do)\n'
+                '            shift\n'
+                '            $1\n'
+                '        ;;\n'
+                '        env)\n'
+                '            shift\n'
+                '            ENVVARS="$1"\n'
+                '        ;;\n'
+                '        cmd)\n'
+                '            shift\n'
+                '            COMMAND="$1"\n'
+                '        ;;\n'
+                '        run)\n'
+                '            shift\n'
+                '            case "$1" in\n')
+            for i, run in enumerate(runs):
+                cmdline = ' '.join([run['binary']] + run['argv'][1:])
+                fp.write(
+                    '                {name})\n'
+                    '                    RUNCOMMAND={cmd}\n'
+                    '                    RUNWD={wd}\n'
+                    '                    RUNENV={env}\n'
+                    '                    RUNUID={uid}\n'
+                    '                    RUNGID={gid}\n'
+                    '                ;;\n'.format(
+                        name='%s|%d' % (run['id'], i),
+                        cmd=shell_escape(cmdline),
+                        wd=shell_escape(run['workingdir']),
+                        env=shell_escape(' '.join(
+                            '%s=%s' % (shell_escape(k), shell_escape(v))
+                            for k, v in iteritems(run['environ']))),
+                        uid=run.get('uid', 1000),
+                        gid=run.get('gid', 1000)))
+            fp.write(
+                '                *)\n'
+                '                    echo "RPZ: Unknown run $1" >&2\n'
+                '                    exit 1\n'
+                '                ;;\n'
+                '            esac\n'
+                '            if [ -n "$COMMAND" ]; then\n'
+                '                RUNCOMMAND="$COMMAND"\n'
+                '                COMMAND=\n'
+                '            fi\n'
+                '            export RUNWD; export RUNENV; export ENVVARS; '
+                'export RUNCOMMAND\n'
+                '            /rpzsudo "#$RUNUID" "#$RUNGID" /busybox sh -c '
+                '"cd \\"\\$RUNWD\\" && /busybox env -i $RUNENV $ENVVARS '
+                '$RUNCOMMAND"\n'
+                '            ENVVARS=\n'
+                '        ;;\n'
+                '        *)\n'
+                '            echo "RPZ: Unknown option $1" >&2\n'
+                '            exit 1\n'
+                '        ;;\n'
+                '    esac\n'
+                '    shift\n'
+                'done\n')
 
         # Meta-data for reprounzip
         write_dict(target, metadata_initial_iofiles(config))

--- a/reprounzip-vagrant/reprounzip/unpackers/vagrant/__init__.py
+++ b/reprounzip-vagrant/reprounzip/unpackers/vagrant/__init__.py
@@ -446,13 +446,10 @@ class LocalX11Handler(BaseX11Handler):
     init_cmds = []
 
     @staticmethod
-    def fix_env(env):
-        """Sets ``$XAUTHORITY`` and ``$DISPLAY`` in the environment.
+    def env_fixes(env):
+        """Sets ``DISPLAY`` and remove ``$XAUTHORITY`` in the environment.
         """
-        new_env = dict(env)
-        new_env.pop('XAUTHORITY', None)
-        new_env['DISPLAY'] = ':0'
-        return new_env
+        return {'DISPLAY': ':0'}, ['XAUTHORITY']
 
 
 @target_must_exist

--- a/reprounzip/reprounzip/unpackers/common/__init__.py
+++ b/reprounzip/reprounzip/unpackers/common/__init__.py
@@ -16,7 +16,7 @@ from reprounzip.unpackers.common.misc import UsageError, \
     composite_action, target_must_exist, unique_names, \
     make_unique_name, shell_escape, load_config, busybox_url, sudo_url, \
     FileUploader, FileDownloader, get_runs, add_environment_options, \
-    fixup_environment, interruptible_call, \
+    parse_environment_args, fixup_environment, interruptible_call, \
     metadata_read, metadata_write, metadata_initial_iofiles, \
     metadata_update_run, parse_ports
 from reprounzip.unpackers.common.packages import THIS_DISTRIBUTION, \
@@ -30,7 +30,7 @@ __all__ = ['THIS_DISTRIBUTION', 'PKG_NOT_INSTALLED', 'select_installer',
            'make_unique_name', 'shell_escape', 'load_config', 'busybox_url',
            'sudo_url',
            'join_root', 'FileUploader', 'FileDownloader', 'get_runs',
-           'add_environment_options', 'fixup_environment',
-           'interruptible_call', 'metadata_read', 'metadata_write',
-           'metadata_initial_iofiles', 'metadata_update_run',
+           'add_environment_options', 'parse_environment_args',
+           'fixup_environment', 'interruptible_call', 'metadata_read',
+           'metadata_write', 'metadata_initial_iofiles', 'metadata_update_run',
            'parse_ports']

--- a/tests/test_reprounzip.py
+++ b/tests/test_reprounzip.py
@@ -135,6 +135,10 @@ class TestCommon(unittest.TestCase):
         old_environ, os.environ = os.environ, outer_env
         try:
             self.assertEqual(
+                reprounzip.unpackers.common.parse_environment_args(
+                    FakeArgs([], [])),
+                ({}, []))
+            self.assertEqual(
                 reprounzip.unpackers.common.fixup_environment(
                     inner_env,
                     FakeArgs([], [])),
@@ -144,6 +148,13 @@ class TestCommon(unittest.TestCase):
                     'SHARED': 'sharedvalue',
                 })
 
+            self.assertEqual(
+                reprounzip.unpackers.common.parse_environment_args(
+                    FakeArgs(['COMMON', 'INONLY', 'OUTONLY', 'EMPTY'], [])),
+                ({'OUTONLY': 'outvalue',
+                  'COMMON': 'commonvalueout',
+                  'EMPTY': ''},
+                 []))
             self.assertEqual(
                 reprounzip.unpackers.common.fixup_environment(
                     inner_env,
@@ -157,6 +168,14 @@ class TestCommon(unittest.TestCase):
                 })
 
             self.assertEqual(
+                reprounzip.unpackers.common.parse_environment_args(
+                    FakeArgs(['OUTONLY'],
+                             ['SHARED=surprise', 'COMMON=', 'INONLY'])),
+                ({'OUTONLY': 'outvalue',
+                  'COMMON': '',
+                  'SHARED': 'surprise'},
+                 ['INONLY']))
+            self.assertEqual(
                 reprounzip.unpackers.common.fixup_environment(
                     inner_env,
                     FakeArgs(['OUTONLY'],
@@ -167,6 +186,10 @@ class TestCommon(unittest.TestCase):
                     'SHARED': 'surprise',
                 })
 
+            self.assertEqual(
+                reprounzip.unpackers.common.parse_environment_args(
+                    FakeArgs(['.*Y$'], [])),
+                ({'OUTONLY': 'outvalue', 'EMPTY': ''}, []))
             self.assertEqual(
                 reprounzip.unpackers.common.fixup_environment(
                     inner_env,


### PR DESCRIPTION
Right now, `reprounzip run` does the work, looking up environment variables/command-lines/... This makes the created Docker images useless by themselves, you need to run them through reprounzip.

By moving some of the run logic from Python to an entrypoint (shell), I can make an image that can be run directly from Docker as well.

Step towards #169

```
$ docker run -ti --rm reprounzip_image_351oi6lubs help
Image built from reprounzip-docker
Usage: docker run <image> [cmd word [word ...]] [run <R>]
    `cmd ...` changes the command for the next `run` option
    `run <name|number>` runs the specified run
By default, all the runs are executed.
The runs in this image are:
    get_data: python 01_getdata.py
    build_classifier: python 02_classifier.py
    predict: python 03_predict.py
    evaluate: python 04_confusion_matrix.py
```
```
$ docker run -ti --rm reprounzip_image_351oi6lubs
Confusion matrix:
[[87  0  0  0  1  0  0  0  0  0]
 [ 0 88  1  0  0  0  0  0  1  1]
 [ 0  0 85  1  0  0  0  0  0  0]
 [ 0  0  0 79  0  3  0  4  5  0]
 [ 0  0  0  0 88  0  0  0  0  4]
 [ 0  0  0  0  0 88  1  0  0  2]
 [ 0  1  0  0  0  0 90  0  0  0]
 [ 0  0  0  0  0  1  0 88  0  0]
 [ 0  0  0  0  0  0  0  0 88  0]
 [ 0  0  0  1  0  1  0  0  0 90]]
```