### PR TITLE
Add usage reporting to reprounzip-qt and reprozip-jupyter

### DIFF
--- a/reprounzip-qt/reprounzip_qt/gui/__init__.py
+++ b/reprounzip-qt/reprounzip_qt/gui/__init__.py
@@ -18,6 +18,7 @@ import reprounzip_qt
 from reprounzip_qt.gui.common import error_msg
 from reprounzip_qt.gui.unpack import UnpackTab
 from reprounzip_qt.gui.run import RunTab
+from reprounzip_qt.usage import record_usage
 
 
 logger = logging.getLogger('reprounzip_qt')
@@ -43,6 +44,7 @@ class Application(QtGui.QApplication):
             out, err = proc.communicate()
             registered = bool(out.strip())
         except OSError:
+            record_usage(appregister='fail xdg-mime')
             logger.info("xdg-mime call failed, not registering application")
         else:
             if not registered:
@@ -54,12 +56,14 @@ class Application(QtGui.QApplication):
                 if r == QtGui.QMessageBox.Yes:
                     self.linux_register_default(window)
                 elif r == QtGui.QMessageBox.No:
+                    record_usage(appregister='no')
                     if not os.path.exists(rcpath):
                         os.mkdir(rcpath)
                     with open(os.path.join(rcpath, rcname), 'w') as fp:
                         fp.write('1\n')
 
     def linux_register_default(self, window):
+        record_usage(appregister='yes')
         command = os.path.abspath(sys.argv[0])
         if not os.path.isfile(command):
             logger.error("Couldn't find argv[0] location!")
@@ -124,6 +128,7 @@ Icon={1}
 
     def event(self, event):
         if event.type() == QtCore.QEvent.FileOpen:
+            record_usage(fileopenevent=True)
             # Create new window for this RPZ
             window = ReprounzipUi(unpack=dict(package=event.file()))
             window.setVisible(True)

--- a/reprounzip-qt/reprounzip_qt/gui/common.py
+++ b/reprounzip-qt/reprounzip_qt/gui/common.py
@@ -4,9 +4,8 @@
 
 from __future__ import division, print_function, unicode_literals
 
-import re
-
 from PyQt4 import QtCore, QtGui
+import re
 
 
 def error_msg(parent, message, severity, details=None):

--- a/reprounzip-qt/reprounzip_qt/gui/run.py
+++ b/reprounzip-qt/reprounzip_qt/gui/run.py
@@ -10,6 +10,7 @@ import yaml
 import reprounzip_qt.reprounzip_interface as reprounzip
 from reprounzip_qt.gui.common import ROOT, ResizableStack, handle_error, \
     error_msg, parse_ports
+from reprounzip_qt.usage import record_usage
 
 
 class RunOptions(QtGui.QWidget):
@@ -86,14 +87,20 @@ class DockerOptions(RunOptions):
 
         if self.tunneled_x11.isChecked():
             options['args'].append('--tunneled-x11')
+            record_usage(docker_tunneled_x11=True)
 
         if self.detach.isChecked():
             options['args'].append('--detach')
+            record_usage(docker_detach=True)
 
+        nb_raw = 0
         for opt in self.raw_options.text().split():
             opt = opt.strip()
             if opt:
+                nb_raw += 1
                 options['args'].append('--docker-option=%s' % opt)
+        if nb_raw:
+            record_usage(docker_raw_options=nb_raw)
 
         ports = parse_ports(self.ports.text(), self)
         if ports is None:
@@ -102,6 +109,7 @@ class DockerOptions(RunOptions):
             options['args'].extend(
                 ['--docker-option=-p',
                  '--docker-option=%s:%s/%s' % (host, container, proto)])
+        record_usage(docker_run_port_fwd=bool(ports))
 
         return options
 
@@ -125,6 +133,7 @@ class VagrantOptions(RunOptions):
         for host, container, proto in parse_ports(self.ports.text(), self):
             options['args'].append('--expose-port=%s:%s/%s' %
                                    (host, container, proto))
+        record_usage(vagrant_run_port_fwd=bool(ports))
 
         return options
 
@@ -175,6 +184,7 @@ class FilesManager(QtGui.QDialog):
                                   ("O" if file_status.is_output else ''),
                                   file_status.name)
             self.files_widget.addItem(text)
+        record_usage(iofiles=self.files_widget.count())
 
     def _file_changed(self):
         selected = [i.row() for i in self.files_widget.selectedIndexes()]
@@ -211,6 +221,7 @@ class FilesManager(QtGui.QDialog):
             self, "Pick file to upload",
             QtCore.QDir.currentPath())
         if picked:
+            record_usage(file_upload=True)
             handle_error(self, reprounzip.upload(
                 self.directory, file_status.name, picked,
                 unpacker=self.unpacker, root=self.root))
@@ -223,6 +234,7 @@ class FilesManager(QtGui.QDialog):
             self, "Pick destination",
             QtCore.QDir.currentPath() + '/' + file_status.name)
         if picked:
+            record_usage(file_download=True)
             handle_error(self, reprounzip.download(
                 self.directory, file_status.name, picked,
                 unpacker=self.unpacker, root=self.root))
@@ -231,6 +243,7 @@ class FilesManager(QtGui.QDialog):
     def _reset(self):
         selected = self.files_widget.selectedIndexes()[0].row()
         file_status = self.files_status[selected]
+        record_usage(file_reset=True)
         handle_error(self, reprounzip.upload(
             self.directory, file_status.name, None,
             unpacker=self.unpacker, root=self.root))
@@ -334,6 +347,7 @@ class RunTab(QtGui.QWidget):
             self, "Pick directory",
             QtCore.QDir.currentPath())
         if picked:
+            record_usage(browse_unpacked=True)
             self.directory_widget.setText(picked)
             self._directory_changed()
 
@@ -385,6 +399,7 @@ class RunTab(QtGui.QWidget):
         if not runs:
             error_msg(self, "No run selected", 'warning')
             return
+        record_usage(run='%d/%d' % (len(runs), self.runs_widget.count()))
         handle_error(self, reprounzip.run(
             self.directory, runs=runs,
             unpacker=self.unpacker,
@@ -418,7 +433,10 @@ class RunTab(QtGui.QWidget):
                 "The experiment is still unpacked with '%s'. Are you sure you "
                 "want to exit without removing it?" % self.unpacker,
                 QtGui.QMessageBox.Yes | QtGui.QMessageBox.No)
-            return r == QtGui.QMessageBox.Yes
+            if r == QtGui.QMessageBox.Yes:
+                record_usage(leave_unpacked=True)
+            else:
+                return False
         else:
             return True
 

--- a/reprounzip-qt/reprounzip_qt/gui/run.py
+++ b/reprounzip-qt/reprounzip_qt/gui/run.py
@@ -4,9 +4,8 @@
 
 from __future__ import division, print_function, unicode_literals
 
-import yaml
-
 from PyQt4 import QtCore, QtGui
+import yaml
 
 import reprounzip_qt.reprounzip_interface as reprounzip
 from reprounzip_qt.gui.common import ROOT, ResizableStack, handle_error, \

--- a/reprounzip-qt/reprounzip_qt/gui/unpack.py
+++ b/reprounzip-qt/reprounzip_qt/gui/unpack.py
@@ -5,9 +5,8 @@
 from __future__ import division, print_function, unicode_literals
 
 import os
-import subprocess
-
 from PyQt4 import QtCore, QtGui
+import subprocess
 
 import reprounzip_qt.reprounzip_interface as reprounzip
 from reprounzip_qt.gui.common import ROOT, ResizableStack, \

--- a/reprounzip-qt/reprounzip_qt/gui/unpack.py
+++ b/reprounzip-qt/reprounzip_qt/gui/unpack.py
@@ -11,6 +11,7 @@ import subprocess
 import reprounzip_qt.reprounzip_interface as reprounzip
 from reprounzip_qt.gui.common import ROOT, ResizableStack, \
     handle_error, error_msg, parse_ports
+from reprounzip_qt.usage import record_usage
 
 
 class UnpackerOptions(QtGui.QWidget):
@@ -68,6 +69,10 @@ class ChrootOptions(UnpackerOptions):
         elif self.magic_dirs.checkState() == QtCore.Qt.Checked:
             options['args'].append('--bind-magic-dirs')
 
+        record_usage(
+            chroot_preserve_owner=self.preserve_owner.checkState(),
+            chroot_magic_dirs=self.magic_dirs.checkState())
+
         return options
 
 
@@ -90,14 +95,18 @@ class DockerOptions(UnpackerOptions):
                 self.machine.addItem("Custom config from environment", None)
             else:
                 self.machine.addItem("Default (no machine)", None)
+            nb_machines = 0
             for machine in out.splitlines():
                 machine = machine.strip()
                 if machine:
                     self.machine.addItem(machine.decode('utf-8', 'replace'),
                                          machine)
+                    nb_machines += 1
+            record_usage(docker_machines=nb_machines)
         except (OSError, subprocess.CalledProcessError):
             self.machine = QtGui.QComboBox(editable=False, enabled=False)
             self.machine.addItem("docker-machine unavailable", None)
+            record_usage(docker_machines=False)
         self.add_row("docker-machine:", self.machine)
 
         self.image = QtGui.QLineEdit(placeholderText='detect')
@@ -116,18 +125,25 @@ class DockerOptions(UnpackerOptions):
         if self.machine.currentIndex() != -1:
             options['docker-machine'] = self.machine.itemData(
                 self.machine.currentIndex())
+            record_usage(
+                use_docker_machine=options['docker-machine'] is not None)
 
         options['root'] = ROOT.INDEX_TO_OPTION[self.root.currentIndex()]
 
         if self.image.text():
             options['args'].extend(['--base-image', self.image.text()])
+            record_usage(docker_base_image=True)
 
         if self.distribution.text():
             options['args'].extend(['--distribution',
                                     self.distribution.text()])
+            record_usage(docker_distribution=True)
 
         if self.install_pkgs.isChecked():
             options['args'].append('--install-pkgs')
+
+        record_usage(root=options['root'],
+                     docker_install_pkgs=self.install_pkgs.isChecked())
 
         return options
 
@@ -168,29 +184,36 @@ class VagrantOptions(UnpackerOptions):
 
         if self.image.text():
             options['args'].extend(['--base-image', self.image.text()])
+            record_usage(vagrant_base_image=True)
 
         if self.distribution.text():
             options['args'].extend(['--distribution',
                                     self.distribution.text()])
+            record_usage(vagrant_distribution=True)
 
         if self.memory.value() != 99:
             options['args'].extend(['--memory', '%d' % self.memory.value()])
+            record_usage(vagrant_memory=self.memory.value())
 
         if self.gui.isChecked():
             options['args'].append('--use-gui')
+            record_usage(vagrant_gui=True)
 
         ports = parse_ports(self.ports.text(), self)
         if ports is None:
             return None
+        record_usage(vagrant_unpack_port_fwd=bool(ports))
         for host, container, proto in ports:
             options['args'].append('--expose-port=%s:%s/%s' % (
                                    host, container, proto))
 
         if not self.use_chroot.isChecked():
             options['args'].append('--dont-use-chroot')
+            record_usage(vagrant_no_chroot=True)
 
         if not self.magic_dirs.isChecked():
             options['args'].append('--dont-bind-magic-dirs')
+            record_usage(vagrant_magic_dirs=False)
 
         return options
 
@@ -276,6 +299,7 @@ class UnpackTab(QtGui.QWidget):
             self, "Pick package file",
             QtCore.QDir.currentPath(), "ReproZip Packages (*.rpz)")
         if picked:
+            record_usage(browse_pkg=True)
             self.package_widget.setText(picked)
             self._package_changed()
 
@@ -305,6 +329,7 @@ class UnpackTab(QtGui.QWidget):
             return
         unpacker = self.unpackers.checkedButton()
         if unpacker:
+            record_usage(unpacker=unpacker.text())
             options = self.unpacker_options.currentWidget().options()
             if options is None:
                 return

--- a/reprounzip-qt/reprounzip_qt/main.py
+++ b/reprounzip-qt/reprounzip_qt/main.py
@@ -11,6 +11,7 @@ import sys
 
 from reprounzip.common import setup_logging
 from reprounzip_qt import __version__
+from reprounzip_qt.usage import record_usage, submit_usage_report
 
 
 logger = logging.getLogger('reprounzip_qt')
@@ -65,21 +66,26 @@ def main():
         sys.exit(2)
     elif args.package:
         logger.info("Got package on the command-line: %s", args.package)
+        record_usage(cmdline='package')
         window_args = dict(unpack=dict(package=args.package))
     elif len(args.unpacked) == 1:
         logger.info("Got unpacked directory on the command-line: %s",
-                    args.unpacked)
+                     args.unpacked)
+        record_usage(cmdline='directory')
         window_args = dict(run=dict(unpacked_directory=args.unpacked[0]),
                            tab=1)
     elif args.unpacked:
         sys.stderr.write("You may only use --unpacked once\n")
         sys.exit(2)
+    else:
+        record_usage(cmdline='empty')
 
     window = ReprounzipUi(**window_args)
     app.set_first_window(window)
     window.setVisible(True)
 
     app.exec_()
+    submit_usage_report()
     sys.exit(0)
 
 

--- a/reprounzip-qt/reprounzip_qt/main.py
+++ b/reprounzip-qt/reprounzip_qt/main.py
@@ -6,9 +6,14 @@ from __future__ import division, print_function, unicode_literals
 
 import argparse
 import locale
+import logging
 import sys
 
+from reprounzip.common import setup_logging
 from reprounzip_qt import __version__
+
+
+logger = logging.getLogger('reprounzip_qt')
 
 
 def qt_init():
@@ -31,6 +36,8 @@ def main():
         epilog="Please report issues to reprozip-users@vgc.poly.edu")
     parser.add_argument('--version', action='version',
                         version="reprounzip-qt version %s" % __version__)
+    parser.add_argument('-v', '--verbose', action='count', default=1,
+                        dest='verbosity', help="augments verbosity level")
     parser.add_argument('package', nargs=argparse.OPTIONAL)
     parser.add_argument('--unpacked', action='append', default=[])
 
@@ -42,6 +49,8 @@ def main():
         else:
             i += 1
     args = parser.parse_args(argv)
+
+    setup_logging('REPROUNZIP-QT', args.verbosity)
 
     qt_init()
 
@@ -55,8 +64,11 @@ def main():
                          "directory\n")
         sys.exit(2)
     elif args.package:
+        logger.info("Got package on the command-line: %s", args.package)
         window_args = dict(unpack=dict(package=args.package))
     elif len(args.unpacked) == 1:
+        logger.info("Got unpacked directory on the command-line: %s",
+                    args.unpacked)
         window_args = dict(run=dict(unpacked_directory=args.unpacked[0]),
                            tab=1)
     elif args.unpacked:

--- a/reprounzip-qt/reprounzip_qt/qt_terminal.py
+++ b/reprounzip-qt/reprounzip_qt/qt_terminal.py
@@ -6,8 +6,12 @@ from __future__ import division, print_function, unicode_literals
 
 import cgi
 import locale
+import logging
 from PyQt4 import QtCore, QtGui
 import sys
+
+
+logger = logging.getLogger('reprounzip_qt')
 
 
 class Terminal(QtGui.QWidget):
@@ -51,6 +55,8 @@ class Terminal(QtGui.QWidget):
         # Add additional environment variables
         for k, v in env.items():
             environ.insert(k, v)
+
+        logger.info("Running in builtin Qt terminal: %r", cmdline)
 
         self.process.setProcessEnvironment(environ)
         self.process.setProcessChannelMode(QtCore.QProcess.SeparateChannels)

--- a/reprounzip-qt/reprounzip_qt/usage.py
+++ b/reprounzip-qt/reprounzip_qt/usage.py
@@ -1,0 +1,40 @@
+# Copyright (C) 2014-2017 New York University
+# This file is part of ReproZip which is released under the Revised BSD License
+# See file LICENSE for full license details.
+
+from __future__ import division, print_function, unicode_literals
+
+import os
+from reprounzip.common import get_reprozip_ca_certificate
+import usagestats
+
+from reprounzip_qt import __version__ as version
+
+
+_certificate_file = get_reprozip_ca_certificate()
+
+_usage_report = usagestats.Stats(
+    '~/.reprozip/usage_stats',
+    usagestats.Prompt(''),
+    os.environ.get('REPROZIP_USAGE_URL', 'https://stats.reprozip.org/'),
+    version=('reprounzip-qt', version),
+    unique_user_id=True,
+    env_var='REPROZIP_USAGE_STATS',
+    ssl_verify=_certificate_file.path
+)
+
+
+def record_usage(**kwargs):
+    """Records some info in the current usage report.
+    """
+    if _usage_report is not None:
+        _usage_report.note(kwargs)
+
+
+def submit_usage_report(**kwargs):
+    """Submits the current usage report to the usagestats server.
+    """
+    _usage_report.submit(kwargs,
+                         usagestats.OPERATING_SYSTEM,
+                         usagestats.SESSION_TIME,
+                         usagestats.PYTHON_VERSION)

--- a/reprounzip-qt/setup.py
+++ b/reprounzip-qt/setup.py
@@ -17,7 +17,7 @@ setup(name='reprounzip-qt',
       entry_points={
           'gui_scripts': [
               'reprounzip-qt = reprounzip_qt.main:main']},
-      install_requires=['PyYAML'],
+      install_requires=['PyYAML', 'reprounzip>=1.0'],
       description="Graphical user interface for reprounzip, using Qt",
       author="Remi Rampin, Fernando Chirigati, Dennis Shasha, Juliana Freire",
       author_email='reprozip-users@vgc.poly.edu',


### PR DESCRIPTION
It might be useful to have reports from there too.

Currently this means they'll have to depend on reprounzip, for 1.1 I plan on breaking up the "common" modules to different PyPI packages.

* [X] Add dependency
* [ ] Add prompt (fixes #240)
* [x] Report feature usage