### PR TITLE
enh: inherit non-zero exit code from traced program

### DIFF
--- a/reprozip/reprozip/tracer/trace.py
+++ b/reprozip/reprozip/tracer/trace.py
@@ -345,6 +345,7 @@ def trace(binary, argv, directory, append, verbosity=1):
                             "signal %d", c & 0xFF)
         else:
             logging.warning("Program exited with non-zero code %d", c)
+        sys.exit(c)
     logging.info("Program completed")
 
 


### PR DESCRIPTION
I am trying to add calls to `reprozip trace` within a continuous integration workflow, and I noticed that, currently, a failing `reprozip trace` returns exit code 0. This makes it difficult to check whether the commands being traced ran successfully. The proposed change exits `reprozip trace` with the same error code as the failing call.

**Current behavior**
```shell
$ reprozip trace cat fakefile.txt
cat: fakefile.txt: No such file or directory
[REPROZIP] 23:58:46.414 WARNING: Program exited with non-zero code 1
Configuration file written in .reprozip-trace/config.yml
Edit that file then run the packer -- use 'reprozip pack -h' for help

Uploading usage statistics is currently disabled
Please help us by providing anonymous usage statistics; you can enable this
by running:
    reprozip usage_report --enable
If you do not want to see this message again, you can run:
    reprozip usage_report --disable
Nothing will be uploaded before you opt in.
$ echo $?
0
```

**Proposed behavior**

```shell
$ reprozip trace cat fakefile.txt
cat: fakefile.txt: No such file or directory
[REPROZIP] 00:00:26.669 WARNING: Program exited with non-zero code 1
$ echo $?
1
$ cat fakefile.txt
cat: fakefile.txt: No such file or directory
$ echo $?
1
```