### PR TITLE
Return the traced command's status, not 0

### DIFF
--- a/reprozip/native/database.c
+++ b/reprozip/native/database.c
@@ -22,7 +22,7 @@ static sqlite3_uint64 gettime(void)
         /* LCOV_EXCL_START : clock_gettime() is unlikely to fail */
         log_critical(0, "getting time failed (clock_gettime): %s",
                      strerror(errno));
-        exit(1);
+        exit(125);
         /* LCOV_EXCL_END */
     }
     timestamp = now.tv_sec;

--- a/reprozip/native/tracer.c
+++ b/reprozip/native/tracer.c
@@ -620,7 +620,7 @@ static void sigint_handler(int signo)
             log_error(0, "cleaning up on SIGINT");
         cleanup();
         restore_signals();
-        exit(1);
+        exit(128 + 2);
     }
     else if(verbosity >= 1)
         log_error(0, "Got SIGINT, press twice to abort...");
@@ -678,7 +678,7 @@ int fork_and_trace(const char *binary, int argc, char **argv,
                 "This could be caused by a security policy or isolation "
                 "mechanism (such as\n Docker), see http://bit.ly/2bZd8Fa",
                 strerror(errno));
-            exit(1);
+            exit(125);
         }
         /* Stop this once so tracer can set options */
         kill(getpid(), SIGSTOP);
@@ -686,7 +686,7 @@ int fork_and_trace(const char *binary, int argc, char **argv,
         execvp(binary, args);
         log_critical(0, "couldn't execute the target command (execvp "
                      "returned): %s", strerror(errno));
-        exit(1);
+        exit(127);
     }
 
     /* Open log file */

--- a/reprozip/reprozip/main.py
+++ b/reprozip/reprozip/main.py
@@ -23,6 +23,7 @@ import os
 from rpaths import Path
 import sqlite3
 import sys
+import traceback
 
 from reprozip import __version__ as reprozip_version
 from reprozip import _pytracer
@@ -388,8 +389,9 @@ def main():
     try:
         status = args.func(args)
     except Exception as e:
+        traceback.print_exc()
         submit_usage_report(result=type(e).__name__)
-        raise
+        sys.exit(125)
     else:
         submit_usage_report(result='success')
     if status is None:

--- a/reprozip/reprozip/main.py
+++ b/reprozip/reprozip/main.py
@@ -277,7 +277,7 @@ def main():
                      "Versions before 2.7.3 are affected by bug 13676 and "
                      "will not work with ReproZip\n" %
                      sys.version.split(' ', 1)[0])
-        sys.exit(1)
+        sys.exit(125)
 
     # Parses command-line
 

--- a/reprozip/reprozip/tracer/trace.py
+++ b/reprozip/reprozip/tracer/trace.py
@@ -316,9 +316,9 @@ def trace(binary, argv, directory, append, verbosity=1):
                     "Trace directory %s exists\n"
                     "Please use either --continue or --overwrite\n",
                     directory)
-                sys.exit(1)
+                sys.exit(125)
             elif r in 'sS':
-                sys.exit(1)
+                sys.exit(125)
             elif r in 'dD':
                 directory.rmtree()
                 directory.mkdir()

--- a/reprozip/reprozip/tracer/trace.py
+++ b/reprozip/reprozip/tracer/trace.py
@@ -347,6 +347,8 @@ def trace(binary, argv, directory, append, verbosity=1):
             logging.warning("Program exited with non-zero code %d", c)
     logging.info("Program completed")
 
+    return c
+
 
 def write_configuration(directory, sort_packages, find_inputs_outputs,
                         overwrite=False):

--- a/tests/functional.py
+++ b/tests/functional.py
@@ -550,7 +550,7 @@ def functional_tests(raise_warnings, interactive, run_vagrant, run_docker):
         # Build
         build('exec_echo32', ['exec_echo.c'], ['-m32'])
         # Trace
-        check_call(rpz + ['testrun', './exec_echo32 42'])
+        check_call(rpz + ['testrun', './exec_echo32', '42'])
     else:
         print("Can't try exec_echo transitions: not running on 64bits")
 
@@ -558,7 +558,8 @@ def functional_tests(raise_warnings, interactive, run_vagrant, run_docker):
     # Tracing non-existing program
     #
 
-    check_call(rpz + ['testrun', './doesntexist'])
+    ret = call(rpz + ['testrun', './doesntexist'])
+    assert ret == 127
 
     # ########################################
     # 'connect' program: testrun
@@ -671,8 +672,9 @@ def functional_tests(raise_warnings, interactive, run_vagrant, run_docker):
     assert rows[0][0] == FILE_WRITE
 
     # Trace a failure: inaccessible file
-    check_call(rpz + ['trace', '--overwrite', '-d', 'readwrite-F-trace',
+    ret = call(rpz + ['trace', '--overwrite', '-d', 'readwrite-F-trace',
                       './readwrite', 'readwrite_test/non/existing/file'])
+    assert ret == 1
 
     # ########################################
     # Test shebang corner-cases


### PR DESCRIPTION
Replaces #281

Returns the exit status from the original command, not always 0. The `trace` and `testrun` commands now use 125 for an internal error.