### PR TITLE
Make `reprounzip docker run` work with a terminal by using pty.spawn()

### DIFF
--- a/reprounzip-docker/reprounzip/unpackers/docker.py
+++ b/reprounzip-docker/reprounzip/unpackers/docker.py
@@ -519,7 +519,8 @@ def docker_run(args):
                                   '-i', '-t'] +
                                  port_options +
                                  args.docker_option +
-                                 [image, '/busybox', 'sh', '-c', cmds])
+                                 [image, '/busybox', 'sh', '-c', cmds],
+                                 request_tty=True)
     if retcode != 0:
         logging.critical("docker run failed with code %d", retcode)
         subprocess.call(['docker', 'rm', '-f', container])

--- a/reprounzip-docker/reprounzip/unpackers/docker.py
+++ b/reprounzip-docker/reprounzip/unpackers/docker.py
@@ -521,14 +521,15 @@ def docker_run(args):
                                  args.docker_option +
                                  [image, '/busybox', 'sh', '-c', cmds],
                                  request_tty=True)
-    if retcode != 0:
+
+    # Get exit status from "docker inspect"
+    try:
+        out = subprocess.check_output(args.docker_cmd.split() +
+                                      ['inspect', container])
+    except subprocess.CalledProcessError:
         logging.critical("docker run failed with code %d", retcode)
         subprocess.call(['docker', 'rm', '-f', container])
         sys.exit(1)
-
-    # Get exit status from "docker inspect"
-    out = subprocess.check_output(args.docker_cmd.split() +
-                                  ['inspect', container])
     outjson = json.loads(out.decode('ascii'))
     if (outjson[0]["State"]["Running"] is not False or
             outjson[0]["State"]["Paused"] is not False):

--- a/reprounzip/reprounzip/unpackers/common/misc.py
+++ b/reprounzip/reprounzip/unpackers/common/misc.py
@@ -443,9 +443,10 @@ else:
         """
         logging.info("Using builtin pty.spawn()")
 
-        import pty, tty
+        import pty
+        import tty
 
-        if type(argv) == type(b''):
+        if isinstance(argv, bytes):
             argv = (argv,)
         pid, master_fd = pty.fork()
         if pid == pty.CHILD:
@@ -482,7 +483,7 @@ def interruptible_call(cmd, **kwargs):
     try:
         if kwargs.pop('request_tty', False):
             try:
-                import pty
+                import pty  # noqa: F401
             except ImportError:
                 pass
             else:


### PR DESCRIPTION
Fixes #291

This uses `pty.spawn()` to allocate a pty if we need to before calling `docker run -ti`

There are some weird issues with the exitcode, which this might make worse. Should probably look into using the inspect JSON only and disregard the `docker run` exitcode.