### PR TITLE
add missing '/' when converting 'expose-port' to docker's '-p' flag

### DIFF
--- a/reprounzip-docker/reprounzip/unpackers/docker.py
+++ b/reprounzip-docker/reprounzip/unpackers/docker.py
@@ -435,7 +435,7 @@ def docker_run(args):
     port_options = []
     for port_host, port_container, proto in parse_ports(args.expose_port):
         port_options.extend(['-p',
-                             '%s:%s%s' % (port_host, port_container, proto)])
+                             '%s:%s/%s' % (port_host, port_container, proto)])
 
     # X11 handler
     if args.x11:


### PR DESCRIPTION
@remram44 - I noticed this when trying to run:

```
$ reprounzip docker run --expose-port 3000:3000 target
...
docker: Invalid containerPort: 3000tcp.
```