### PR TITLE
Moved examples to main navbar

### DIFF
--- a/about.html
+++ b/about.html
@@ -53,7 +53,6 @@
               <div class="dropdown-menu" aria-labelledby="navbarDropdown">
                 <a class="dropdown-item active" href="#">What is ReproZip?</a>
                 <a class="dropdown-item" href="https://docs.reprozip.org/">Docs <i class="fas fa-external-link-alt"></i></a>
-                <a class="dropdown-item" href="https://examples.reprozip.org/">Examples <i class="fas fa-external-link-alt"></i></a>
               </div>
             </li><!--end about dropdown-->
 
@@ -87,6 +86,8 @@
                 </li>
               </ul>
             </li><!--end installers dropdown-->
+                
+          <li class="nav-item"><a class="nav-link" href="https://examples.reprozip.org/">Examples <i class="fas fa-external-link-alt"></i></a></li>
 
           </ul><!--end left navbar-->
           <!-- right navbar -->

--- a/index.html
+++ b/index.html
@@ -54,7 +54,6 @@
               <div class="dropdown-menu" aria-labelledby="navbarDropdown">
                 <a class="dropdown-item" href="about.html">What is ReproZip?</a>
                 <a class="dropdown-item" href="https://docs.reprozip.org/">Docs <i class="fas fa-external-link-alt"></i></a>
-                <a class="dropdown-item" href="https://examples.reprozip.org/">Examples <i class="fas fa-external-link-alt"></i></a>
               </div>
             </li><!--end about dropdown-->
 
@@ -88,6 +87,9 @@
                 </li>
               </ul>
             </li><!--end installers dropdown-->
+        
+          <li class="nav-item"><a class="nav-link" href="https://examples.reprozip.org/">Examples <i class="fas fa-external-link-alt"></i></a></li>        
+        
           </ul><!--end left navbar-->
           <!-- right navbar -->
           <ul class="nav navbar-nav ml-auto">

--- a/reprozip-dev-job.html
+++ b/reprozip-dev-job.html
@@ -52,9 +52,7 @@
               <a class="nav-link dropdown-toggle" href="#" id="navbarDropdown" role="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">About</a>
               <div class="dropdown-menu" aria-labelledby="navbarDropdown">
                 <a class="dropdown-item" href="about.html">What is ReproZip?</a>
-                <a class="dropdown-item" href="https://docs.reprozip.org/">Docs <i class="fas fa-external-link-alt"></i></a>
-                <a class="dropdown-item" href="https://examples.reprozip.org/">Examples <i class="fas fa-external-link-alt"></i></a>
-              </div>
+                <a class="dropdown-item" href="https://docs.reprozip.org/">Docs <i class="fas fa-external-link-alt"></i></a>              </div>
             </li><!--end about dropdown-->
 
             <li class="nav-item"><a class="nav-link" href="schol.html">Scholarship</a></li>
@@ -87,6 +85,8 @@
                 </li>
               </ul>
             </li><!--end installers dropdown-->
+        
+          <li class="nav-item"><a class="nav-link" href="https://examples.reprozip.org/">Examples <i class="fas fa-external-link-alt"></i></a></li>
 
           </ul><!--end left navbar-->
           <!-- right navbar -->

--- a/schol.html
+++ b/schol.html
@@ -53,7 +53,6 @@
               <div class="dropdown-menu" aria-labelledby="navbarDropdown">
                 <a class="dropdown-item" href="about.html">What is ReproZip?</a>
                 <a class="dropdown-item" href="https://docs.reprozip.org/">Docs <i class="fas fa-external-link-alt"></i></a>
-                <a class="dropdown-item" href="https://examples.reprozip.org/">Examples <i class="fas fa-external-link-alt"></i></a>
               </div>
             </li><!--end about dropdown-->
 
@@ -87,6 +86,8 @@
                 </li>
               </ul>
             </li><!--end installers dropdown-->
+        
+        <li class="nav-item"><a class="nav-link" href="https://examples.reprozip.org/">Examples <i class="fas fa-external-link-alt"></i></a></li>
 
           </ul><!--end left navbar-->
           <!-- right navbar -->


### PR DESCRIPTION
People ask me about example usage of ReproZip all the time, so we should probably move this up to the main navbar on the website to make it more visible. 