### PR TITLE
Changed decoding to UTF-8

### DIFF
--- a/reprounzip-docker/reprounzip/unpackers/docker.py
+++ b/reprounzip-docker/reprounzip/unpackers/docker.py
@@ -536,7 +536,7 @@ def docker_run(args):
         logger.critical("docker run failed with code %d", retcode)
         subprocess.call(['docker', 'rm', '-f', container])
         sys.exit(1)
-    outjson = json.loads(out.decode('ascii'))
+    outjson = json.loads(out.decode('utf-8'))
     if (outjson[0]["State"]["Running"] is not False or
             outjson[0]["State"]["Paused"] is not False):
         logger.error("Invalid container state after execution:\n%s",


### PR DESCRIPTION
I changed the decoding done in the docker unpacker to UTF-8 from ascii.
The unpacker wasn't working for me until i did this (localization
issue?) Is there any reason not to use UTF-8 decoding ihere?