### PR TITLE
Develop custom 'tar' replacement to merge bundle with existing system

### DIFF
--- a/reprounzip/reprounzip/parameters.py
+++ b/reprounzip/reprounzip/parameters.py
@@ -100,6 +100,12 @@ _bundled_parameters = {
         "i686": "https://github.com/remram44/static-sudo/releases/download/"
                 "current/rpzsudo-i686"
     },
+    "rpztar_url": {
+        "x86_64": "https://github.com/remram44/rpztar/releases/download/"
+                  "v1/rpztar-x86_64",
+        "i686": "https://github.com/remram44/rpztar/releases/download/"
+                "v1/rpztar-i686"
+    },
     "docker_images": {
         "default": "debian",
         "images": {

--- a/reprounzip/reprounzip/unpackers/common/__init__.py
+++ b/reprounzip/reprounzip/unpackers/common/__init__.py
@@ -15,6 +15,7 @@ from reprounzip.unpackers.common.misc import UsageError, \
     COMPAT_OK, COMPAT_NO, COMPAT_MAYBE, \
     composite_action, target_must_exist, unique_names, \
     make_unique_name, shell_escape, load_config, busybox_url, sudo_url, \
+    rpztar_url, \
     FileUploader, FileDownloader, get_runs, add_environment_options, \
     fixup_environment, interruptible_call, \
     metadata_read, metadata_write, metadata_initial_iofiles, \
@@ -28,7 +29,7 @@ __all__ = ['THIS_DISTRIBUTION', 'PKG_NOT_INSTALLED', 'select_installer',
            'UsageError', 'CantFindInstaller',
            'composite_action', 'target_must_exist', 'unique_names',
            'make_unique_name', 'shell_escape', 'load_config', 'busybox_url',
-           'sudo_url',
+           'sudo_url', 'rpztar_url',
            'join_root', 'FileUploader', 'FileDownloader', 'get_runs',
            'add_environment_options', 'fixup_environment',
            'interruptible_call', 'metadata_read', 'metadata_write',

--- a/reprounzip/reprounzip/unpackers/common/misc.py
+++ b/reprounzip/reprounzip/unpackers/common/misc.py
@@ -135,6 +135,12 @@ def sudo_url(arch):
     return get_parameter('rpzsudo_url')[arch]
 
 
+def rpztar_url(arch):
+    """Gets the correct URL for the rpztar binary given the architecture.
+    """
+    return get_parameter('rpztar_url')[arch]
+
+
 class FileUploader(object):
     """Common logic for 'upload' commands.
     """


### PR DESCRIPTION
This will behave correctly in situations where we need to unpack a file or link over a directory, without wiping whole directories when unneeded.

Written in Rust using the [`tar`](https://docs.rs/tar/) library and compiled to a static executable (repo: [remram44/rpztar](https://github.com/remram44/rpztar)). Similar to `rpzsudo` but I couldn't easily implement tar support in C...

Should probably be used for Vagrant as well (at least when `use_chroot=False`).

This also allows us to support Docker images or Vagrant images that don't have tar.