### PR TITLE
Fix invocation through PATH in directory unpacker

### DIFF
--- a/reprounzip/reprounzip/unpackers/default.py
+++ b/reprounzip/reprounzip/unpackers/default.py
@@ -283,6 +283,10 @@ def directory_run(args):
         if cmdline is None:
             argv = run['argv']
 
+            # If the command is not a path, use the path instead
+            if '/' not in argv[0]:
+                argv = [run['binary']] + argv[1:]
+
             # Rewrites command-line arguments that are absolute filenames
             rewritten = False
             for i in irange(len(argv)):


### PR DESCRIPTION
It doesn't look like `ld-linux.so` uses PATH to locate the target, so we'll have to give the full path. This means it won't get its expected `arg0` but I don't see how to work around it.