### PR TITLE
Print warnings for systemd

### DIFF
--- a/reprounzip/reprounzip/common.py
+++ b/reprounzip/reprounzip/common.py
@@ -737,7 +737,7 @@ def setup_logging(tag, verbosity):
     file_level = logging.INFO
     min_level = min(console_level, file_level)
 
-    # Create formatter, with same format as C extension
+    # Create formatter
     fmt = "[%s] %%(asctime)s %%(levelname)s: %%(message)s" % tag
     formatter = LoggingDateFormatter(fmt)
 

--- a/reprounzip/reprounzip/common.py
+++ b/reprounzip/reprounzip/common.py
@@ -49,6 +49,7 @@ FILE_WRITE = 0x02
 FILE_WDIR = 0x04
 FILE_STAT = 0x08
 FILE_LINK = 0x10
+FILE_SOCKET = 0x20
 
 
 class File(object):

--- a/reprozip/native/database.h
+++ b/reprozip/native/database.h
@@ -6,6 +6,7 @@
 #define FILE_WDIR   0x04  /* File is used as a process's working dir */
 #define FILE_STAT   0x08  /* File is stat()d (only metadata is read) */
 #define FILE_LINK   0x10  /* The link itself is accessed, no dereference */
+#define FILE_SOCKET 0x20  /* The file is a UNIX domain socket */
 
 int db_init(const char *filename);
 int db_close(int rollback);

--- a/reprozip/native/syscalls.c
+++ b/reprozip/native/syscalls.c
@@ -13,6 +13,7 @@
 #include <sys/stat.h>
 #include <sys/syscall.h>
 #include <sys/types.h>
+#include <sys/un.h>
 #include <unistd.h>
 
 #include "config.h"
@@ -86,6 +87,14 @@ static const char *print_sockaddr(void *address, socklen_t addrlen)
         char buf[50];
         inet_ntop(AF_INET6, &address_->sin6_addr, buf, sizeof(buf));
         snprintf(buffer, 512, "[%s]:%d", buf, ntohs(address_->sin6_port));
+    }
+    else if(family == AF_UNIX)
+    {
+        struct sockaddr_un *address_ = address;
+        char buf[109];
+        strncpy(buf, &address_->sun_path, 108);
+        buf[108] = 0;
+        snprintf(buffer, 512, "unix:%s", buf);
     }
     else
         snprintf(buffer, 512, "<unknown destination, sa_family=%d>", family);

--- a/reprozip/native/syscalls.c
+++ b/reprozip/native/syscalls.c
@@ -895,6 +895,21 @@ static int handle_connect(struct Process *process,
         tracee_read(process->tid, address, arg1, addrlen);
         log_info(process->tid, "process connected to %s",
                  print_sockaddr(address, addrlen));
+
+        const short family = ((struct sockaddr*)address)->sa_family;
+        if(family == AF_UNIX)
+        {
+            struct sockaddr_un *address_ = address;
+            char buf[109];
+            strncpy(buf, &address_->sun_path, 108);
+            buf[108] = 0;
+            if(db_add_file_open(process->identifier,
+                                buf,
+                                FILE_SOCKET | FILE_WRITE,
+                                0) != 0)
+                return -1; /* LCOV_EXCL_LINE */
+        }
+
         free(address);
     }
     return 0;

--- a/reprozip/native/syscalls.c
+++ b/reprozip/native/syscalls.c
@@ -69,39 +69,6 @@ static char *abs_path_arg(const struct Process *process, size_t arg)
 }
 
 
-static const char *print_sockaddr(void *address, socklen_t addrlen)
-{
-    static char buffer[512];
-    const short family = ((struct sockaddr*)address)->sa_family;
-    if(family == AF_INET && addrlen >= sizeof(struct sockaddr_in))
-    {
-        struct sockaddr_in *address_ = address;
-        snprintf(buffer, 512, "%s:%d",
-                inet_ntoa(address_->sin_addr),
-                ntohs(address_->sin_port));
-    }
-    else if(family == AF_INET6
-          && addrlen >= sizeof(struct sockaddr_in6))
-    {
-        struct sockaddr_in6 *address_ = address;
-        char buf[50];
-        inet_ntop(AF_INET6, &address_->sin6_addr, buf, sizeof(buf));
-        snprintf(buffer, 512, "[%s]:%d", buf, ntohs(address_->sin6_port));
-    }
-    else if(family == AF_UNIX)
-    {
-        struct sockaddr_un *address_ = address;
-        char buf[109];
-        strncpy(buf, &address_->sun_path, 108);
-        buf[108] = 0;
-        snprintf(buffer, 512, "unix:%s", buf);
-    }
-    else
-        snprintf(buffer, 512, "<unknown destination, sa_family=%d>", family);
-    return buffer;
-}
-
-
 /* ********************
  * Other syscalls that might be of interest but that we don't handle yet
  */
@@ -870,6 +837,46 @@ int syscall_fork_event(struct Process *process, unsigned int event)
  * Network connections
  */
 
+static int handle_socket(struct Process *process, const char *msg,
+                         void *address, socklen_t addrlen)
+{
+    const short family = ((struct sockaddr*)address)->sa_family;
+    if(family == AF_INET && addrlen >= sizeof(struct sockaddr_in))
+    {
+        struct sockaddr_in *address_ = address;
+        log_info(process->tid, "%s %s:%d", msg,
+                 inet_ntoa(address_->sin_addr),
+                 ntohs(address_->sin_port));
+    }
+    else if(family == AF_INET6
+          && addrlen >= sizeof(struct sockaddr_in6))
+    {
+        struct sockaddr_in6 *address_ = address;
+        char buf[50];
+        inet_ntop(AF_INET6, &address_->sin6_addr, buf, sizeof(buf));
+        log_info(process->tid, "%s [%s]:%d", msg,
+                 buf, ntohs(address_->sin6_port));
+    }
+    else if(family == AF_UNIX)
+    {
+        struct sockaddr_un *address_ = address;
+        char buf[109];
+        strncpy(buf, &address_->sun_path, 108);
+        buf[108] = 0;
+        log_info(process->tid, "%s unix:%s", msg, buf);
+
+        if(db_add_file_open(process->identifier,
+                            buf,
+                            FILE_SOCKET | FILE_WRITE,
+                            0) != 0)
+            return -1; /* LCOV_EXCL_LINE */
+    }
+    else
+        log_info(process->tid, "%s <unknown destination, sa_family=%d>",
+                 msg, family);
+    return 0;
+}
+
 static int handle_accept(struct Process *process,
                          void *arg1, void *arg2)
 {
@@ -879,8 +886,9 @@ static int handle_accept(struct Process *process,
     {
         void *address = malloc(addrlen);
         tracee_read(process->tid, address, arg1, addrlen);
-        log_info(process->tid, "process accepted a connection from %s",
-                 print_sockaddr(address, addrlen));
+        if(handle_socket(process, "process accepted a connection from",
+                         address, addrlen) != 0)
+            return -1; /* LCOV_EXCL_LINE */
         free(address);
     }
     return 0;
@@ -893,23 +901,9 @@ static int handle_connect(struct Process *process,
     {
         void *address = malloc(addrlen);
         tracee_read(process->tid, address, arg1, addrlen);
-        log_info(process->tid, "process connected to %s",
-                 print_sockaddr(address, addrlen));
-
-        const short family = ((struct sockaddr*)address)->sa_family;
-        if(family == AF_UNIX)
-        {
-            struct sockaddr_un *address_ = address;
-            char buf[109];
-            strncpy(buf, &address_->sun_path, 108);
-            buf[108] = 0;
-            if(db_add_file_open(process->identifier,
-                                buf,
-                                FILE_SOCKET | FILE_WRITE,
-                                0) != 0)
-                return -1; /* LCOV_EXCL_LINE */
-        }
-
+        if(handle_socket(process, "process connected to",
+                         address, addrlen) != 0)
+            return -1; /* LCOV_EXCL_LINE */
         free(address);
     }
     return 0;

--- a/reprozip/reprozip/common.py
+++ b/reprozip/reprozip/common.py
@@ -737,7 +737,7 @@ def setup_logging(tag, verbosity):
     file_level = logging.INFO
     min_level = min(console_level, file_level)
 
-    # Create formatter, with same format as C extension
+    # Create formatter
     fmt = "[%s] %%(asctime)s %%(levelname)s: %%(message)s" % tag
     formatter = LoggingDateFormatter(fmt)
 

--- a/reprozip/reprozip/common.py
+++ b/reprozip/reprozip/common.py
@@ -49,6 +49,7 @@ FILE_WRITE = 0x02
 FILE_WDIR = 0x04
 FILE_STAT = 0x08
 FILE_LINK = 0x10
+FILE_SOCKET = 0x20
 
 
 class File(object):


### PR DESCRIPTION
Fixes #45

This is a rather big change because it add a new flag for files in the `opened_files` table, `FILE_SOCKET`. The Python tracer then checks that against systemd UNIX socket locations to print a warning.

![Screenshot of warning in terminal](https://user-images.githubusercontent.com/426784/222625498-dedbdb49-4519-43ea-9395-bd8a751ade28.png)