### PR TITLE
Use strlcpy instead of strncpy

### DIFF
--- a/reprozip/native/syscalls.c
+++ b/reprozip/native/syscalls.c
@@ -861,7 +861,7 @@ static int handle_socket(struct Process *process, const char *msg,
     {
         struct sockaddr_un *address_ = address;
         char buf[109];
-        strncpy(buf, &address_->sun_path, 108);
+        strlcpy(buf, address_->sun_path, 108);
         buf[108] = 0;
         log_info(process->tid, "%s unix:%s", msg, buf);
 


### PR DESCRIPTION
On Debian, it will report as below:
native/syscalls.c:864:22: error: passing argument 2 of ‘strncpy’ from incompatible pointer type [-Wincompatible-pointer-types]
  864 |         strncpy(buf, &address_->sun_path, 108);
      |                      ^~~~~~~~~~~~~~~~~~~
      |                      |
      |                      char (*)[108]